### PR TITLE
feat: install Sensei skill in cloud agent environment

### DIFF
--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: ".github/skills/**/*.md"
+applyTo: ".github/skills/**/SKILL.md"
 ---
 
 # Skill Authoring — Sensei Auto-Invocation

--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -1,0 +1,55 @@
+---
+applyTo: ".github/skills/**/*.md"
+---
+
+# Skill Authoring — Sensei Auto-Invocation
+
+After **creating or modifying** any `SKILL.md` file under `.github/skills/`, you must
+automatically run the Sensei skill to validate and improve frontmatter compliance.
+
+## When to Invoke Sensei
+
+Invoke Sensei immediately after:
+- Creating a new skill (`SKILL.md`)
+- Editing an existing `SKILL.md` (description, triggers, or body content)
+- Moving or renaming a skill directory
+
+Do **not** invoke Sensei for changes to `references/*.md`, test files, or other
+non-`SKILL.md` files inside a skill directory.
+
+## How to Invoke
+
+Use the Sensei skill (already installed at `~/.copilot/skills/sensei/`):
+
+```
+Run sensei on <skill-name>
+```
+
+Or for faster iteration when tests are not yet written:
+
+```
+Run sensei on <skill-name> --fast
+```
+
+Sensei will execute the Ralph Loop — scoring the frontmatter, improving triggers,
+checking token budget — and iterate until the skill reaches **Medium-High** compliance.
+
+## Handling the "Prompt User" Step (Step 10) in Cloud Agent Mode
+
+Sensei's Step 10 asks the user to choose: Commit (C), Create Issue (I), or Skip (S).
+
+In the cloud agent context:
+1. **Post a GitHub comment** on the issue/PR summarizing the before/after score:
+   - Before score (Low/Medium/etc.), after score, token delta, trigger count
+2. **Ask the user** to reply with C, I, or S
+3. **If you cannot wait for a reply** (e.g., running in a fully automated context):
+   - If score >= Medium-High: **Commit** with message `sensei: improve <skill-name> frontmatter`
+   - If score < Medium-High after 5 iterations: **Create Issue** with the suggestions
+
+## Target Score
+
+Aim for **Medium-High** or higher:
+- Description ≥ 150 chars, ≤ 60 words
+- Contains `WHEN:` trigger phrases (preferred) or `USE FOR:`
+- No `DO NOT USE FOR:` (risky in multi-skill environments)
+- `SKILL.md` < 500 tokens

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,41 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation,
+# and allow manual testing through the repository's "Actions" tab.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: v2/package-lock.json
+
+      - name: Install project dependencies
+        working-directory: v2
+        run: npm ci
+
+      - name: Install Sensei skill
+        run: |
+          mkdir -p "$HOME/.copilot/skills"
+          git clone https://github.com/spboyer/sensei.git "$HOME/.copilot/skills/sensei"
+          cd "$HOME/.copilot/skills/sensei/scripts" && npm install

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,6 +27,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Create .env for CI
+        run: |
+          cat > .env <<'EOF'
+          GITHUB_TOKEN=placeholder
+          GITHUB_ORG=placeholder
+          GITHUB_REPO=placeholder
+          PG_HOST=postgres
+          PG_PORT=5432
+          PG_DATABASE=dora_metrics
+          PG_USER=postgres
+          PG_PASSWORD=postgres
+          PORT=3003
+          DATA_MODE=seed
+          DATA_SOURCE_LABEL=ci
+          DATA_SOURCE_URL=https://github.com
+          EOF
+
       - name: Start services
         run: docker compose up -d
         env:


### PR DESCRIPTION
/skills/**/*.md\\:
- Automatically invokes Sensei (Ralph Loop) after any \SKILL.md\ create/edit
- Targets **Medium-High** frontmatter compliance
- Defines cloud agent behavior for the interactive Prompt step (GitHub comment → C/I/S)

## Why
The cloud agent runs in an ephemeral GitHub Actions environment with no pre-installed user skills. \copilot-setup-steps.yml\ runs in the same environment before the agent starts, so anything installed there persists for the session. The path-specific instruction keeps the Sensei trigger non-intrusive — it only fires when working on skill files.