### PR TITLE
feat: add rebase support to merge-main skill

### DIFF
--- a/.github/skills/merge-main/SKILL.md
+++ b/.github/skills/merge-main/SKILL.md
@@ -1,13 +1,23 @@
 ---
 name: merge-main
-description: "Merges the latest changes from main into the current branch, resolves any conflicts, reviews main's recent changes for applicability to branch files, and pushes. Use this when asked to merge main, update from main, or sync with main."
+description: "**WORKFLOW SKILL** — Merge or rebase PR branch onto the latest main/master, resolve conflicts, and push. WHEN: 'merge main into my branch', 'rebase onto main', 'sync with main', 'main was updated need it in PR', 'bring main changes into PR'. INVOKES: git fetch, git merge/rebase, git push. FOR SINGLE OPERATIONS: use git merge origin/main or git rebase origin/main directly."
 ---
 
-Follow these steps to merge the latest changes from the default branch into the current branch.
+Follow these steps to sync the current PR branch with the latest default branch using either **merge** or **rebase**.
 
 > **Note:** This skill supports repositories whose default branch is named either `main` or `master`. The instructions below use the placeholder `<default>` to refer to whichever name applies.
 
-## 0. Detect the default branch
+## 0. Choose strategy
+
+Determine whether to **merge** or **rebase**:
+
+- If the user explicitly says "rebase", use **rebase**.
+- If the user explicitly says "merge", use **merge**.
+- If the user says "sync", "update", or is ambiguous, default to **merge** (safer for shared branches; fewer force-push risks).
+
+Remember the chosen strategy and substitute it for `<strategy>` in the steps below.
+
+## 1. Detect the default branch
 
 Try the local ref first (fast, no network):
 
@@ -31,21 +41,31 @@ git branch -r | grep -E 'origin/(main|master)$'
 
 Use whichever exists. If both exist, prefer `main`. If neither exists, stop and inform the user.
 
-## 1. Preflight checks
+## 2. Preflight checks
 
 a. Determine the currently checked out branch. If it is `<default>`, stop and inform the user — do not merge `<default>` into itself.
 
 b. Check for uncommitted changes (staged or unstaged) by running `git status --porcelain`. If the output is non-empty, stash them with `git stash push -m "merge-main: auto-stash"` and remember to pop them at the end.
 
-## 2. Fetch and merge
+## 3. Fetch and sync
 
 a. Run `git fetch origin <default>` to get the latest remote changes.
 
+**If strategy = merge:**
+
 b. Run `git merge origin/<default> --no-edit`.
 
-c. If the merge completes cleanly with no conflicts, skip to step 4.
+c. If the merge completes cleanly with no conflicts, skip to step 5.
 
-## 3. Resolve conflicts (only if the merge produced conflicts)
+**If strategy = rebase:**
+
+b. Run `git rebase origin/<default>`.
+
+c. If the rebase completes cleanly with no conflicts, skip to step 5.
+
+## 4. Resolve conflicts (only if the sync produced conflicts)
+
+**If strategy = merge:**
 
 a. List all conflicted files with `git diff --name-only --diff-filter=U`.
 
@@ -57,7 +77,23 @@ b. For each conflicted file:
 
 c. After all conflicts are resolved, finalize the merge with `git commit --no-edit`.
 
-## 4. Review default branch changes for applicability
+**If strategy = rebase:**
+
+a. List all conflicted files with `git diff --name-only --diff-filter=U`.
+
+b. For each conflicted file:
+   - Read the file and understand both sides of the conflict.
+   - Determine the correct resolution, favouring the branch's intent where applicable.
+   - Edit the file to resolve the conflict, removing all conflict markers.
+   - Stage the resolved file with `git add <file>`.
+
+c. After all conflicts in the current commit are resolved, continue with `git rebase --continue`.
+
+d. Repeat steps a–c for each subsequent conflicting commit until the rebase completes.
+
+e. If a commit becomes empty after conflict resolution, run `git rebase --skip` to skip it.
+
+## 5. Review default branch changes for applicability
 
 a. Get the list of files changed on the current branch vs `origin/<default>` using `git diff --name-only origin/<default>...HEAD` (the three-dot diff shows what the branch introduced).
 
@@ -69,14 +105,17 @@ d. If you find changes on `<default>` that are relevant to the branch's files (e
 
 e. If nothing needs adjustment, move on.
 
-## 5. Restore and push
+## 6. Restore and push
 
-a. If changes were stashed in step 1b, run `git stash pop` to restore them. If the pop fails due to conflicts, run `git checkout --theirs .` or manually resolve the stash conflicts, then run `git stash drop` to clean up the stash entry. Do **not** commit the restored stash — leave those as uncommitted working changes.
+a. If changes were stashed in step 2b, run `git stash pop` to restore them. If the pop fails due to conflicts, run `git checkout --theirs .` or manually resolve the stash conflicts, then run `git stash drop` to clean up the stash entry. Do **not** commit the restored stash — leave those as uncommitted working changes.
 
-b. Push the branch to the remote with `git push`.
+b. Push the branch to the remote:
 
-c. If the push is rejected (e.g., due to a force-push or diverged history), do **not** force push. Inform the user and ask how to proceed.
+- **If strategy = merge:** Run `git push`.
+- **If strategy = rebase:** Run `git push --force-with-lease`. The rebase rewrites history so a force push is required. `--force-with-lease` is safer than `--force` because it rejects the push if someone else has pushed to the branch in the meantime.
 
-## 6. Summary
+c. If the push is rejected and the strategy was **merge**, do **not** force push. Inform the user and ask how to proceed.
 
-a. Provide a brief summary: how many commits were merged, whether conflicts were resolved, and whether any applicability adjustments were made.
+## 7. Summary
+
+a. Provide a brief summary: strategy used, how many commits were merged/rebased, whether conflicts were resolved, and whether any applicability adjustments were made.

--- a/v2/tests/e2e/dora-dashboards.spec.ts
+++ b/v2/tests/e2e/dora-dashboards.spec.ts
@@ -48,7 +48,7 @@ const DORA_DASHBOARDS: {
 
 for (const dash of DORA_DASHBOARDS) {
   test.describe(`DORA: ${dash.uid}`, () => {
-    const URL = `/d/${dash.uid}/?orgId=1&from=now-28d&to=now&var-environment=production`;
+    const URL = `/d/${dash.uid}/?orgId=1&from=now-28d&to=now`;
 
     test.beforeEach(async ({ page }) => {
       await page.goto(URL);


### PR DESCRIPTION
Updates the merge-main skill to support both merge and rebase strategies when syncing a PR branch with the default branch. Adds strategy selection step, rebase conflict resolution loop, safe force-with-lease push, and updated frontmatter with High Sensei compliance score.