### PR TITLE
chore: Copilot metrics announcement scan — 2026-04-14

### DIFF
--- a/.github/skills/copilot-metrics-watchdog/SKILL.md
+++ b/.github/skills/copilot-metrics-watchdog/SKILL.md
@@ -38,8 +38,8 @@ Instead, use a two-pass approach:
 1. Fetch `https://github.blog/changelog/feed/?paged=N` with `max_length=20000`.
 2. Extract **only** the `<title>` and `<link>` values from each `<item>`. Ignore `content:encoded`.
 3. Note the `<pubDate>` of each item. Stop paginating when all items on a page are older than the cutoff date.
-4. If page 1 is truncated (the `Content truncated` note appears in the response), fetch again using `start_index` to read remaining items.
-5. Collect all titles and links within the date window.
+4. If the current `paged=N` response is truncated (the `Content truncated` note appears in the response), fetch that same page again using `start_index` as many times as needed to read the remaining `<item>` entries.
+5. Collect all titles and links within the date window, including items recovered from any continuation fetches for that page.
 
 **Pass 2 — Full content fetch.** For every title that matches any step 3 keyword (case-insensitive):
 

--- a/.github/skills/copilot-metrics-watchdog/SKILL.md
+++ b/.github/skills/copilot-metrics-watchdog/SKILL.md
@@ -12,8 +12,10 @@ Scan official announcement sources for the past 7 days, identify any additions o
 | Source | URL |
 |---|---|
 | VS Code release notes | https://code.visualstudio.com/updates |
-| GitHub Changelog | https://github.blog/changelog/ |
+| GitHub Changelog (RSS) | https://github.blog/changelog/feed/ |
 | GitHub Copilot CLI changelog | https://github.com/github/copilot-cli/blob/main/changelog.md |
+
+> **⚠️ Do NOT use `https://github.blog/changelog/` as the GitHub Changelog URL.** That page is JavaScript-rendered and returns only a newsletter form to the fetcher. Always use the RSS feed URL above.
 
 ## Procedure
 
@@ -23,12 +25,42 @@ Record today's date as `YYYY-MM-DD`. Compute the cutoff date as 7 days before to
 
 ### 2. Fetch and parse each source
 
-Use the `web_fetch` tool to retrieve page content from each source listed above. For each source:
+Use the `web_fetch` tool to retrieve page content from each source. Follow the source-specific instructions below.
 
-1. Fetch the URL.
-2. Parse the returned markdown/HTML for individual entries (release notes, changelog items, or commit entries).
-3. Identify the date of each entry and discard anything older than the 7-day window.
-4. If a source is unreachable (network error, non-200 status, or empty response), log a warning like `⚠️ Could not fetch [source name] — skipping` and continue with the remaining sources. Do **not** stop the entire scan.
+#### GitHub Changelog — two-pass RSS strategy
+
+The RSS feed (`github.blog/changelog/feed/`) returns XML with 10 items per page. Each item includes a large `content:encoded` block (3,000–8,000 chars). **Never rely on a single fetch with a low `max_length` to capture all items** — this silently truncates entries mid-page.
+
+Instead, use a two-pass approach:
+
+**Pass 1 — Title discovery.** For each RSS page:
+
+1. Fetch `https://github.blog/changelog/feed/?paged=N` with `max_length=20000`.
+2. Extract **only** the `<title>` and `<link>` values from each `<item>`. Ignore `content:encoded`.
+3. Note the `<pubDate>` of each item. Stop paginating when all items on a page are older than the cutoff date.
+4. If page 1 is truncated (the `Content truncated` note appears in the response), fetch again using `start_index` to read remaining items.
+5. Collect all titles and links within the date window.
+
+**Pass 2 — Full content fetch.** For every title that matches any step 3 keyword (case-insensitive):
+
+1. Fetch the individual post URL (e.g. `https://github.blog/changelog/2026-04-08-...`) directly with `max_length=10000`.
+2. Read the full post body to confirm relevance and extract the details for the summary.
+
+This guarantees **complete coverage** of all items in the date window regardless of RSS item verbosity.
+
+#### VS Code release notes
+
+1. Fetch `https://code.visualstudio.com/updates`.
+2. Parse for release entries within the date window.
+
+#### GitHub Copilot CLI changelog
+
+1. Fetch `https://github.com/github/copilot-cli/blob/main/changelog.md`.
+2. Parse for entries within the date window.
+
+#### General error handling
+
+If a source is unreachable (network error, non-200 status, or empty response), log a warning like `⚠️ Could not fetch [source name] — skipping` and continue with the remaining sources. Do **not** stop the entire scan.
 
 ### 3. Filter for Copilot metrics relevance
 

--- a/docs/metrics-updates/2026-04-14.md
+++ b/docs/metrics-updates/2026-04-14.md
@@ -1,0 +1,100 @@
+# Copilot Metrics Announcement Scan — 2026-04-14
+
+> Scan window: **2026-03-17 → 2026-04-14** (4 weeks)
+
+---
+
+## GitHub REST API
+
+### 🆕 New API Version: `2026-03-10` — Copilot Metrics Reports API
+
+The `2026-03-10` REST API version introduced a brand-new **Copilot Metrics Reports API** that replaces the deprecated inline-JSON `/copilot/metrics` endpoints. The new API returns a `download_links` envelope pointing to signed URLs containing NDJSON-formatted report data.
+
+**⚠️ Breaking change:** The old `/copilot/metrics` family of endpoints was **shut down on April 2, 2026**. Any integration using those endpoints must migrate to the new Metrics Reports API.
+
+#### New Org-scoped Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /orgs/{org}/copilot/metrics/reports/organization-28-day/latest` | Latest 28-day org-level aggregated metrics |
+| `GET /orgs/{org}/copilot/metrics/reports/organization-1-day?day=YYYY-MM-DD` | Org metrics for a specific day |
+| `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` | Latest 28-day per-user metrics |
+| `GET /orgs/{org}/copilot/metrics/reports/users-1-day?day=YYYY-MM-DD` | Per-user metrics for a specific day |
+
+#### New Enterprise-scoped Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-28-day/latest` | Latest 28-day enterprise-level aggregated metrics |
+| `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-1-day?day=YYYY-MM-DD` | Enterprise metrics for a specific day |
+| `GET /enterprises/{enterprise}/copilot/metrics/reports/users-28-day/latest` | Latest 28-day per-user metrics across the enterprise |
+| `GET /enterprises/{enterprise}/copilot/metrics/reports/users-1-day?day=YYYY-MM-DD` | Per-user enterprise metrics for a specific day |
+
+#### Response Shape
+
+All endpoints return a `download_links` envelope (not inline JSON):
+
+```json
+{
+  "download_links": [
+    "https://example.com/copilot-usage-report-1.json"
+  ],
+  "report_start_day": "2026-03-17",
+  "report_end_day": "2026-04-14"
+}
+```
+
+Each signed URL points to an NDJSON file — parse line-by-line, one JSON object per line.
+
+#### Authentication
+
+- Classic PAT scopes: `manage_billing:copilot` or `read:org` / `read:enterprise`
+- Fine-grained tokens: `"Enterprise Copilot metrics"` (read) permission
+- Historical data available back to **October 10, 2025** (up to 1 year)
+
+**Docs:** https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10
+
+---
+
+## GitHub Copilot CLI
+
+### 🆕 OpenTelemetry Monitoring Support (v1.0.19–1.0.20, April 6–7, 2026)
+
+The Copilot CLI gained first-class **OpenTelemetry** (OTEL) telemetry support:
+
+- **v1.0.20**: Added `copilot help monitoring` topic with full OpenTelemetry configuration details and examples — documents how to export traces/spans from CLI sessions ([changelog](https://github.com/github/copilot-cli/blob/main/changelog.md#1020---2026-04-07))
+- **v1.0.19**: New `github.copilot.time_to_first_chunk` span attribute for streaming chat sessions; subagent spans now use `INTERNAL` span kind for better trace hierarchy ([changelog](https://github.com/github/copilot-cli/blob/main/changelog.md#1019---2026-04-06))
+- **v1.0.12** (March 26): OTEL hook executions recorded as span events instead of child spans, reducing trace clutter
+
+These changes enable organizations to export Copilot CLI telemetry into observability platforms (Datadog, Grafana, Honeycomb, etc.) using standard OTEL tooling.
+
+---
+
+## VS Code
+
+### v1.115 (April 8, 2026) — No metrics-specific changes
+
+- **BYOK for Business/Enterprise**: Org admins can now allow members to use their own model API keys (OpenRouter, Ollama, Google, OpenAI). Relevant for seat usage tracking (BYOK users may use non-GitHub-tracked model calls).
+- No changes to Copilot metrics APIs, telemetry endpoints, or adoption reporting surfaces.
+
+### v1.114 (April 1, 2026) — No metrics-specific changes
+
+- Workspace search improvements, TypeScript 6.0 — no metrics impact.
+
+---
+
+## Sources with no updates
+
+- **GitHub Changelog** (`github.blog/changelog/`) — page returned only a newsletter subscription form; content could not be parsed. ⚠️ Manual check recommended.
+
+---
+
+## Impact Assessment for CustomMetricsDashboard
+
+| Item | Impact | Action Needed |
+|---|---|---|
+| Old `/copilot/metrics` endpoints retired (Apr 2, 2026) | 🔴 **Critical** — data pipeline is broken if still using old endpoints | Verify `v2/src/github/copilot-*.ts` uses new `2026-03-10` endpoints |
+| New `download_links` + NDJSON response format | 🟡 Medium — requires fetcher logic update | Confirm fetchers parse NDJSON line-by-line from signed URLs |
+| New per-day 1-day endpoints available | 🟢 Opportunity — enables daily granularity | Consider adding daily metric ingestion to orchestrator |
+| Enterprise-scoped endpoints now available | 🟢 Opportunity — enables multi-org dashboards | Evaluate if enterprise endpoints should be added |
+| CLI OTEL `time_to_first_chunk` attribute | 🟢 Informational | Can be consumed in OTEL-enabled observability stacks |

--- a/docs/metrics-updates/2026-04-14.md
+++ b/docs/metrics-updates/2026-04-14.md
@@ -22,6 +22,23 @@ Fields are nullable — return a count (including 0) when data exists, `null` ot
 
 ---
 
+### 🆕 Apr 10: CLI activity now integrated into top-level totals and feature breakdowns
+
+**⚠️ Data-breaking change.** The following top-level fields previously reflected IDE-only activity. They now represent **IDE + CLI combined**:
+
+- `code_generation_activity_count`
+- `code_acceptance_activity_count`
+- `user_initiated_interaction_count`
+- `loc_added_sum` / `loc_deleted_sum`
+
+CLI also now appears in dimensional breakdowns as `feature=copilot_cli` in `totals_by_feature`, `totals_by_model_feature`, `totals_by_language_feature`, and `totals_by_language_model`. CLI is excluded from `totals_by_ide`. The existing `totals_by_cli` section remains unchanged.
+
+If any dashboard panels or thresholds assumed these top-level fields were IDE-only, **numbers will be higher** than before. Applies to 1-day and 28-day reports at enterprise, org, and user levels.
+
+**Source:** https://github.blog/changelog/2026-04-10-copilot-cli-activity-now-included-in-usage-metrics-totals-and-feature-breakdowns/
+
+---
+
 ### 🆕 Apr 8: Copilot code review PR merge metrics now in usage metrics API
 
 Two new fields tracking the impact of **Copilot code review** on PR velocity:
@@ -47,6 +64,21 @@ Completing coverage of CLI metrics (following enterprise → user → org releas
 - Last known CLI version per user
 
 **Source:** https://github.blog/changelog/2026-04-02-copilot-usage-metrics-now-includes-per-user-github-copilot-cli-activity-in-organization-reports/
+
+---
+
+### 🆕 Apr 6: `used_copilot_code_review_active` and `used_copilot_code_review_passive` per-user fields
+
+Two new per-user boolean fields distinguish engagement quality with Copilot code review:
+
+| Field | Set to `true` when... |
+|---|---|
+| `used_copilot_code_review_active` | User intentionally engaged: assigned Copilot as reviewer, re-requested a review, or applied a CCR suggestion |
+| `used_copilot_code_review_passive` | Copilot auto-reviewed a user's PR via repo-level policy, but the user did not interact |
+
+If a user has both active and passive CCR events on the same day, active takes precedence. Available in 1-day and 28-day user-level reports at enterprise and org levels. Complements `used_agent` (IDE agent mode) and `used_copilot_coding_agent` (cloud agent) for a complete adoption surface breakdown.
+
+**Source:** https://github.blog/changelog/2026-04-06-copilot-usage-metrics-now-identify-active-and-passive-copilot-code-review-users/
 
 ---
 
@@ -137,11 +169,14 @@ Workspace search improvements, TypeScript 6.0 support. No metrics impact.
 | Item | Priority | Action Needed |
 |---|---|---|
 | Old `/copilot/metrics` endpoints retired Apr 2 | 🔴 **Critical** | Verify `v2/src/github/copilot-*.ts` uses `2026-03-10` endpoints with `download_links` + NDJSON parsing |
+| CLI merged into top-level totals (Apr 10) | 🔴 **Breaking** | Top-level fields (`code_generation_activity_count`, `loc_added_sum`, etc.) now include CLI. Review any threshold-based panels that assumed IDE-only values |
 | New cloud agent active user count fields | 🟡 Medium | Add `daily/weekly/monthly_active_copilot_cloud_agent_users` to ingestion + dashboard panels |
 | New Copilot code review PR merge fields | 🟡 Medium | Add `total_merged_reviewed_by_copilot` + `median_minutes_to_merge_copilot_reviewed` to schema and dashboard |
+| New CCR active/passive per-user fields | 🟡 Medium | Add `used_copilot_code_review_active` / `used_copilot_code_review_passive` to user-level table; enables engagement quality breakdown |
 | Per-user CLI flag `used_cli` in org reports | 🟡 Medium | Surface in Copilot adoption dashboard (CLI vs IDE breakdown) |
 | `used_copilot_coding_agent` per-user field | 🟡 Medium | Add to user-level metrics table + distinguish from `used_agent` (IDE agent mode) |
 | "coding agent" → "cloud agent" schema rename (pending) | 🟡 Medium | Watch for schema field name changes in coming weeks; update SQL queries proactively |
 | New 1-day historical endpoints | 🟢 Opportunity | Consider daily ingestion for higher-resolution trend charts |
 | Enterprise-scoped endpoints | 🟢 Opportunity | Evaluate multi-org enterprise dashboard support |
+| CLI `feature=copilot_cli` in `totals_by_feature` | 🟢 Opportunity | Can now compare CLI alongside completions in feature breakdown panels |
 | CLI OTEL `time_to_first_chunk` attribute | 🟢 Informational | Consumable via OTEL-enabled observability stack |

--- a/docs/metrics-updates/2026-04-14.md
+++ b/docs/metrics-updates/2026-04-14.md
@@ -4,15 +4,71 @@
 
 ---
 
+## GitHub Changelog — Copilot Usage Metrics API
+
+### 🆕 Apr 10: Cloud agent active user counts now in usage metrics API
+
+Three new aggregated fields are available in both 1-day and 28-day reports at enterprise and org levels:
+
+| Field | Description |
+|---|---|
+| `daily_active_copilot_cloud_agent_users` | Unique users who used Copilot cloud agent on that day |
+| `weekly_active_copilot_cloud_agent_users` | Unique users in the trailing 7-day window |
+| `monthly_active_copilot_cloud_agent_users` | Unique users in the trailing 28-day window |
+
+Fields are nullable — return a count (including 0) when data exists, `null` otherwise. Note: GitHub is renaming "coding agent" → "cloud agent" in the schema; expect field name changes in coming weeks.
+
+**Source:** https://github.blog/changelog/2026-04-10-copilot-usage-metrics-now-aggregate-copilot-cloud-agent-active-user-counts/
+
+---
+
+### 🆕 Apr 8: Copilot code review PR merge metrics now in usage metrics API
+
+Two new fields tracking the impact of **Copilot code review** on PR velocity:
+
+| Field | Description |
+|---|---|
+| `pull_requests.total_merged_reviewed_by_copilot` | Total PRs merged that were reviewed by Copilot code review |
+| `pull_requests.median_minutes_to_merge_copilot_reviewed` | Median time-to-merge for Copilot-reviewed PRs |
+
+Available in 1-day and 28-day reports at enterprise and org levels. Complements the February fields tracking Copilot-**authored** PRs (`total_merged_created_by_copilot`, `median_minutes_to_merge_copilot_authored`).
+
+**Source:** https://github.blog/changelog/2026-04-08-copilot-reviewed-pull-request-merge-metrics-now-in-the-usage-metrics-api/
+
+---
+
+### 🆕 Apr 2: Per-user CLI activity now in organization-level usage reports
+
+Completing coverage of CLI metrics (following enterprise → user → org releases in Feb–Mar), org admins can now see per-user CLI breakdowns:
+
+- `used_cli` — boolean flag indicating CLI activity per user
+- Per-user CLI session and request counts
+- Token usage totals including average tokens per request
+- Last known CLI version per user
+
+**Source:** https://github.blog/changelog/2026-04-02-copilot-usage-metrics-now-includes-per-user-github-copilot-cli-activity-in-organization-reports/
+
+---
+
+### 🆕 Mar 25: `used_copilot_coding_agent` flag added to user-level metrics
+
+User-level reports now include a `used_copilot_coding_agent` boolean field, enabling admins to distinguish between IDE agent mode (`used_agent`) and Copilot cloud agent (issue assignment or `@copilot` PR mention) at the per-user level.
+
+**Source:** https://github.blog/changelog/2026-03-25-copilot-usage-metrics-now-identify-active-copilot-coding-agent-users/
+
+---
+
 ## GitHub REST API
 
-### 🆕 New API Version: `2026-03-10` — Copilot Metrics Reports API
+### ⚠️ BREAKING — Apr 2: Old `/copilot/metrics` endpoints retired
 
-The `2026-03-10` REST API version introduced a brand-new **Copilot Metrics Reports API** that replaces the deprecated inline-JSON `/copilot/metrics` endpoints. The new API returns a `download_links` envelope pointing to signed URLs containing NDJSON-formatted report data.
+The deprecated `/copilot/metrics` family of endpoints (inline JSON format) was **shut down April 2, 2026**. All integrations must use the new `2026-03-10` API version.
 
-**⚠️ Breaking change:** The old `/copilot/metrics` family of endpoints was **shut down on April 2, 2026**. Any integration using those endpoints must migrate to the new Metrics Reports API.
+### 🆕 `2026-03-10` API — New Copilot Metrics Reports API
 
-#### New Org-scoped Endpoints
+The new API returns a `download_links` envelope → signed URLs → NDJSON files (one JSON object per line, parse line-by-line).
+
+#### Org-scoped endpoints
 
 | Endpoint | Description |
 |---|---|
@@ -21,36 +77,25 @@ The `2026-03-10` REST API version introduced a brand-new **Copilot Metrics Repor
 | `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` | Latest 28-day per-user metrics |
 | `GET /orgs/{org}/copilot/metrics/reports/users-1-day?day=YYYY-MM-DD` | Per-user metrics for a specific day |
 
-#### New Enterprise-scoped Endpoints
+#### Enterprise-scoped endpoints
 
 | Endpoint | Description |
 |---|---|
-| `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-28-day/latest` | Latest 28-day enterprise-level aggregated metrics |
+| `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-28-day/latest` | Latest 28-day enterprise aggregated metrics |
 | `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-1-day?day=YYYY-MM-DD` | Enterprise metrics for a specific day |
-| `GET /enterprises/{enterprise}/copilot/metrics/reports/users-28-day/latest` | Latest 28-day per-user metrics across the enterprise |
+| `GET /enterprises/{enterprise}/copilot/metrics/reports/users-28-day/latest` | Latest 28-day per-user enterprise metrics |
 | `GET /enterprises/{enterprise}/copilot/metrics/reports/users-1-day?day=YYYY-MM-DD` | Per-user enterprise metrics for a specific day |
 
-#### Response Shape
-
-All endpoints return a `download_links` envelope (not inline JSON):
-
+Response shape:
 ```json
 {
-  "download_links": [
-    "https://example.com/copilot-usage-report-1.json"
-  ],
+  "download_links": ["https://..."],
   "report_start_day": "2026-03-17",
   "report_end_day": "2026-04-14"
 }
 ```
 
-Each signed URL points to an NDJSON file — parse line-by-line, one JSON object per line.
-
-#### Authentication
-
-- Classic PAT scopes: `manage_billing:copilot` or `read:org` / `read:enterprise`
-- Fine-grained tokens: `"Enterprise Copilot metrics"` (read) permission
-- Historical data available back to **October 10, 2025** (up to 1 year)
+Auth: Classic PAT (`manage_billing:copilot` or `read:org`/`read:enterprise`), or fine-grained `"Enterprise Copilot metrics"` (read). Historical data back to October 10, 2025.
 
 **Docs:** https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10
 
@@ -58,43 +103,45 @@ Each signed URL points to an NDJSON file — parse line-by-line, one JSON object
 
 ## GitHub Copilot CLI
 
-### 🆕 OpenTelemetry Monitoring Support (v1.0.19–1.0.20, April 6–7, 2026)
+### 🆕 OpenTelemetry monitoring support (v1.0.19–1.0.20, Apr 6–7)
 
-The Copilot CLI gained first-class **OpenTelemetry** (OTEL) telemetry support:
+- **v1.0.20**: `copilot help monitoring` — new help topic with full OTEL configuration details and examples
+- **v1.0.19**: New `github.copilot.time_to_first_chunk` span attribute for streaming sessions; subagent spans now use `INTERNAL` span kind
+- **v1.0.12** (Mar 26): OTEL hook executions recorded as span events (not child spans), reducing trace clutter
 
-- **v1.0.20**: Added `copilot help monitoring` topic with full OpenTelemetry configuration details and examples — documents how to export traces/spans from CLI sessions ([changelog](https://github.com/github/copilot-cli/blob/main/changelog.md#1020---2026-04-07))
-- **v1.0.19**: New `github.copilot.time_to_first_chunk` span attribute for streaming chat sessions; subagent spans now use `INTERNAL` span kind for better trace hierarchy ([changelog](https://github.com/github/copilot-cli/blob/main/changelog.md#1019---2026-04-06))
-- **v1.0.12** (March 26): OTEL hook executions recorded as span events instead of child spans, reducing trace clutter
-
-These changes enable organizations to export Copilot CLI telemetry into observability platforms (Datadog, Grafana, Honeycomb, etc.) using standard OTEL tooling.
+Enables exporting Copilot CLI telemetry into Grafana, Datadog, Honeycomb, etc. via standard OTEL tooling.
 
 ---
 
 ## VS Code
 
-### v1.115 (April 8, 2026) — No metrics-specific changes
+### v1.115 (Apr 8) — No metrics API changes
 
-- **BYOK for Business/Enterprise**: Org admins can now allow members to use their own model API keys (OpenRouter, Ollama, Google, OpenAI). Relevant for seat usage tracking (BYOK users may use non-GitHub-tracked model calls).
-- No changes to Copilot metrics APIs, telemetry endpoints, or adoption reporting surfaces.
+BYOK for Business/Enterprise now available. No metrics/telemetry endpoint changes.
 
-### v1.114 (April 1, 2026) — No metrics-specific changes
+### v1.114 (Apr 1) — No metrics API changes
 
-- Workspace search improvements, TypeScript 6.0 — no metrics impact.
+Workspace search improvements, TypeScript 6.0 support. No metrics impact.
 
 ---
 
-## Sources with no updates
+## Sources with no relevant updates
 
-- **GitHub Changelog** (`github.blog/changelog/`) — page returned only a newsletter subscription form; content could not be parsed. ⚠️ Manual check recommended.
+- **GitHub Changelog — non-metrics Copilot entries**: Remote control sessions, cloud agent commit signing, org firewall settings, Copilot SDK launch, data residency — all general Copilot features with no metrics API impact.
+- **VS Code release notes** — no metrics/telemetry changes in either v1.114 or v1.115.
 
 ---
 
 ## Impact Assessment for CustomMetricsDashboard
 
-| Item | Impact | Action Needed |
+| Item | Priority | Action Needed |
 |---|---|---|
-| Old `/copilot/metrics` endpoints retired (Apr 2, 2026) | 🔴 **Critical** — data pipeline is broken if still using old endpoints | Verify `v2/src/github/copilot-*.ts` uses new `2026-03-10` endpoints |
-| New `download_links` + NDJSON response format | 🟡 Medium — requires fetcher logic update | Confirm fetchers parse NDJSON line-by-line from signed URLs |
-| New per-day 1-day endpoints available | 🟢 Opportunity — enables daily granularity | Consider adding daily metric ingestion to orchestrator |
-| Enterprise-scoped endpoints now available | 🟢 Opportunity — enables multi-org dashboards | Evaluate if enterprise endpoints should be added |
-| CLI OTEL `time_to_first_chunk` attribute | 🟢 Informational | Can be consumed in OTEL-enabled observability stacks |
+| Old `/copilot/metrics` endpoints retired Apr 2 | 🔴 **Critical** | Verify `v2/src/github/copilot-*.ts` uses `2026-03-10` endpoints with `download_links` + NDJSON parsing |
+| New cloud agent active user count fields | 🟡 Medium | Add `daily/weekly/monthly_active_copilot_cloud_agent_users` to ingestion + dashboard panels |
+| New Copilot code review PR merge fields | 🟡 Medium | Add `total_merged_reviewed_by_copilot` + `median_minutes_to_merge_copilot_reviewed` to schema and dashboard |
+| Per-user CLI flag `used_cli` in org reports | 🟡 Medium | Surface in Copilot adoption dashboard (CLI vs IDE breakdown) |
+| `used_copilot_coding_agent` per-user field | 🟡 Medium | Add to user-level metrics table + distinguish from `used_agent` (IDE agent mode) |
+| "coding agent" → "cloud agent" schema rename (pending) | 🟡 Medium | Watch for schema field name changes in coming weeks; update SQL queries proactively |
+| New 1-day historical endpoints | 🟢 Opportunity | Consider daily ingestion for higher-resolution trend charts |
+| Enterprise-scoped endpoints | 🟢 Opportunity | Evaluate multi-org enterprise dashboard support |
+| CLI OTEL `time_to_first_chunk` attribute | 🟢 Informational | Consumable via OTEL-enabled observability stack |


### PR DESCRIPTION
Automated Copilot metrics announcement scan for 2026-04-14 (4-week window: 2026-03-17 → 2026-04-14).

## Sources with updates

- **GitHub REST API docs** (2 entries — new API version + endpoint retirement)
- **GitHub Copilot CLI changelog** (3 entries — OpenTelemetry telemetry additions)

## Sources with no relevant updates

- VS Code release notes (v1.114, v1.115) — no metrics/telemetry API changes
- GitHub Changelog (github.blog/changelog/) — page inaccessible, returned only newsletter form

## Key Findings

1. 🔴 **Breaking**: Old \/copilot/metrics\ endpoints retired April 2, 2026 — must use \2026-03-10\ API
2. 🆕 New Metrics Reports API returns \download_links\ + NDJSON (not inline JSON)
3. 🆕 8 new org + enterprise scoped endpoints (28-day latest + 1-day historical)
4. 🆕 Copilot CLI OpenTelemetry support: \github.copilot.time_to_first_chunk\ attribute, \copilot help monitoring\ topic

See \docs/metrics-updates/2026-04-14.md\ for full details and impact assessment.