### PR TITLE
fix: data mode banner shows empty/red on all dashboards

### DIFF
--- a/.github/skills/playwright-screenshots/SKILL.md
+++ b/.github/skills/playwright-screenshots/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: playwright-screenshots
+description: "**WORKFLOW SKILL** — Capture before/after Grafana dashboard screenshots when JSON, SQL, or seed data changes. Saves PNGs to v2/screenshots/ and commits them to the current PR for visual review. WHEN: \"take dashboard screenshots\", \"capture before and after\", \"screenshot dashboard changes\", \"visual diff dashboards\", \"commit dashboard screenshots\"."
+---
+
+# Playwright Dashboard Screenshots
+
+Capture before/after screenshots of Grafana dashboards affected by the current change set and commit them to the PR for visual review.
+
+## When to Use
+
+- Dashboard JSON files changed (`v2/grafana/dashboards/*.json`)
+- Grafana SQL queries modified inside dashboard panels
+- Seed data or schema changes that affect rendered panels
+- User requests visual confirmation of dashboard changes
+
+## Prerequisites
+
+The docker-compose stack must be running with seeded data:
+
+```bash
+cd v2
+docker-compose up -d          # add --build if TypeScript source files changed
+npm run seed                   # only if database is empty
+```
+
+Grafana is available at `http://localhost:3004` (admin/admin).
+
+## Dashboard Catalog
+
+| File | UID | Kiosk URL |
+|------|-----|-----------|
+| 00-overview.json | `overview` | `/d/overview?orgId=1&kiosk` |
+| 01-deployment-frequency.json | `deploy-freq` | `/d/deploy-freq?orgId=1&kiosk` |
+| 02-lead-time.json | `lead-time` | `/d/lead-time?orgId=1&kiosk` |
+| 03-change-failure-rate.json | `change-fail` | `/d/change-fail?orgId=1&kiosk` |
+| 04-mean-time-to-recovery.json | `mttr` | `/d/mttr?orgId=1&kiosk` |
+| 05-copilot-adoption.json | `copilot-adopt` | `/d/copilot-adopt?orgId=1&kiosk` |
+| 06-copilot-code-impact.json | `copilot-impact` | `/d/copilot-impact?orgId=1&kiosk` |
+| 07-dora-vs-copilot.json | `dora-copilot` | `/d/dora-copilot?orgId=1&kiosk` |
+
+## Procedure
+
+### 1. Identify affected dashboards
+
+Run `git diff --name-only` against the base branch to find changed files under `v2/grafana/dashboards/`. If seed data or schema files changed, treat **all** dashboards as affected.
+
+### 2. Capture "before" screenshots
+
+Before applying dashboard changes, for each affected dashboard:
+
+1. Navigate to `http://admin:admin@localhost:3004/d/<uid>?orgId=1&kiosk`
+2. Wait for panels: use `waitForLoadState('load')` + `waitForTimeout(3000)` — do **not** use `waitForLoadState('networkidle')` (Grafana's WebSocket keeps it from resolving)
+3. Scroll through the full page to trigger below-the-fold panel rendering
+4. Save screenshot to `v2/screenshots/before-<uid>.png`
+
+Using Playwright MCP (cloud agent):
+
+```
+navigate to http://admin:admin@localhost:3004/d/<uid>?orgId=1&kiosk
+wait for load
+take screenshot → v2/screenshots/before-<uid>.png
+```
+
+Using Playwright CLI (local agent):
+
+```bash
+npx playwright screenshot \
+  "http://admin:admin@localhost:3004/d/<uid>?orgId=1&kiosk" \
+  v2/screenshots/before-<uid>.png
+```
+
+### 3. Apply changes
+
+Make the dashboard JSON, SQL, or seed data edits. If Grafana auto-provisions dashboards, changes take effect on the next page load.
+
+### 4. Capture "after" screenshots
+
+Repeat step 2 for each affected dashboard, saving to `v2/screenshots/after-<uid>.png`.
+
+### 5. Commit screenshots to the PR
+
+```bash
+git add v2/screenshots/before-*.png v2/screenshots/after-*.png
+git commit -m "docs: add before/after dashboard screenshots"
+```
+
+Use `report_progress` in cloud agent mode to push.
+
+### 6. Summarize changes
+
+Post a comment or update the PR description listing each dashboard with its before/after screenshot pair so reviewers can visually compare.
+
+## Grafana Selector Notes
+
+- Table cells render as `role="cell"` (not `role="gridcell"`)
+- Use `[role="row"]:has([role="cell"])` for data row selectors
+- Panels use `[data-panelid]` attributes
+- Do **not** use `waitForLoadState('networkidle')` — the WebSocket prevents resolution
+
+## Error Handling
+
+- **Grafana not running**: Prompt the user to start the docker-compose stack
+- **Empty panels / "No data"**: Check if `npm run seed` has been run; verify `v2-postgres-1` is healthy
+- **Screenshot directory missing**: Create `v2/screenshots/` before saving

--- a/.github/skills/playwright-screenshots/SKILL.md
+++ b/.github/skills/playwright-screenshots/SKILL.md
@@ -1,105 +1,49 @@
 ---
 name: playwright-screenshots
-description: "**WORKFLOW SKILL** — Capture before/after Grafana dashboard screenshots when JSON, SQL, or seed data changes. Saves PNGs to v2/screenshots/ and commits them to the current PR for visual review. WHEN: \"take dashboard screenshots\", \"capture before and after\", \"screenshot dashboard changes\", \"visual diff dashboards\", \"commit dashboard screenshots\"."
+description: "**WORKFLOW SKILL** — Capture before/after Grafana dashboard screenshots when JSON, SQL, or seed data changes. Saves PNGs to v2/screenshots/ for PR visual review. WHEN: \"take dashboard screenshots\", \"capture before and after\", \"screenshot dashboard changes\", \"visual diff dashboards\", \"commit dashboard screenshots\". INVOKES: Playwright MCP, git. FOR SINGLE OPERATIONS: Use Playwright MCP directly."
 ---
 
 # Playwright Dashboard Screenshots
 
-Capture before/after screenshots of Grafana dashboards affected by the current change set and commit them to the PR for visual review.
-
-## When to Use
-
-- Dashboard JSON files changed (`v2/grafana/dashboards/*.json`)
-- Grafana SQL queries modified inside dashboard panels
-- Seed data or schema changes that affect rendered panels
-- User requests visual confirmation of dashboard changes
+Capture before/after screenshots of Grafana dashboards and commit them to the PR.
 
 ## Prerequisites
 
-The docker-compose stack must be running with seeded data:
+Docker-compose stack running with seeded data:
 
 ```bash
-cd v2
-docker-compose up -d          # add --build if TypeScript source files changed
-npm run seed                   # only if database is empty
+cd v2 && docker-compose up -d && npm run seed
 ```
-
-Grafana is available at `http://localhost:3004` (admin/admin).
-
-## Dashboard Catalog
-
-| File | UID | Kiosk URL |
-|------|-----|-----------|
-| 00-overview.json | `overview` | `/d/overview?orgId=1&kiosk` |
-| 01-deployment-frequency.json | `deploy-freq` | `/d/deploy-freq?orgId=1&kiosk` |
-| 02-lead-time.json | `lead-time` | `/d/lead-time?orgId=1&kiosk` |
-| 03-change-failure-rate.json | `change-fail` | `/d/change-fail?orgId=1&kiosk` |
-| 04-mean-time-to-recovery.json | `mttr` | `/d/mttr?orgId=1&kiosk` |
-| 05-copilot-adoption.json | `copilot-adopt` | `/d/copilot-adopt?orgId=1&kiosk` |
-| 06-copilot-code-impact.json | `copilot-impact` | `/d/copilot-impact?orgId=1&kiosk` |
-| 07-dora-vs-copilot.json | `dora-copilot` | `/d/dora-copilot?orgId=1&kiosk` |
 
 ## Procedure
 
 ### 1. Identify affected dashboards
 
-Run `git diff --name-only` against the base branch to find changed files under `v2/grafana/dashboards/`. If seed data or schema files changed, treat **all** dashboards as affected.
+Use `git diff --name-only` to find changed files under `v2/grafana/dashboards/`. If seed data or schema changed, treat all dashboards as affected. Dashboard UIDs are in each JSON file's `"uid"` field.
 
 ### 2. Capture "before" screenshots
 
-Before applying dashboard changes, for each affected dashboard:
-
-1. Navigate to `http://admin:admin@localhost:3004/d/<uid>?orgId=1&kiosk`
-2. Wait for panels: use `waitForLoadState('load')` + `waitForTimeout(3000)` — do **not** use `waitForLoadState('networkidle')` (Grafana's WebSocket keeps it from resolving)
-3. Scroll through the full page to trigger below-the-fold panel rendering
-4. Save screenshot to `v2/screenshots/before-<uid>.png`
-
-Using Playwright MCP (cloud agent):
-
-```
-navigate to http://admin:admin@localhost:3004/d/<uid>?orgId=1&kiosk
-wait for load
-take screenshot → v2/screenshots/before-<uid>.png
-```
-
-Using Playwright CLI (local agent):
-
-```bash
-npx playwright screenshot \
-  "http://admin:admin@localhost:3004/d/<uid>?orgId=1&kiosk" \
-  v2/screenshots/before-<uid>.png
-```
+For each affected dashboard, navigate to `http://admin:admin@localhost:3004/d/<uid>?orgId=1&kiosk`. Use `waitForLoadState('load')` + `waitForTimeout(3000)` — **never** `networkidle` (Grafana WebSocket blocks it). Scroll the full page, then save to `v2/screenshots/before-<uid>.png`.
 
 ### 3. Apply changes
 
-Make the dashboard JSON, SQL, or seed data edits. If Grafana auto-provisions dashboards, changes take effect on the next page load.
+Edit dashboard JSON, SQL, or seed data. Grafana auto-provisions on reload.
 
 ### 4. Capture "after" screenshots
 
-Repeat step 2 for each affected dashboard, saving to `v2/screenshots/after-<uid>.png`.
+Repeat step 2, saving to `v2/screenshots/after-<uid>.png`.
 
-### 5. Commit screenshots to the PR
+### 5. Commit and summarize
 
 ```bash
-git add v2/screenshots/before-*.png v2/screenshots/after-*.png
+git add v2/screenshots/{before,after}-*.png
 git commit -m "docs: add before/after dashboard screenshots"
 ```
 
-Use `report_progress` in cloud agent mode to push.
-
-### 6. Summarize changes
-
-Post a comment or update the PR description listing each dashboard with its before/after screenshot pair so reviewers can visually compare.
-
-## Grafana Selector Notes
-
-- Table cells render as `role="cell"` (not `role="gridcell"`)
-- Use `[role="row"]:has([role="cell"])` for data row selectors
-- Panels use `[data-panelid]` attributes
-- Do **not** use `waitForLoadState('networkidle')` — the WebSocket prevents resolution
+Use `report_progress` to push. Update the PR description with before/after pairs.
 
 ## Error Handling
 
-- **Grafana not running**: Prompt the user to start the docker-compose stack
-- **Empty panels / "No data"**: Check if `npm run seed` has been run; verify `v2-postgres-1` is healthy
-- **Screenshot directory missing**: Create `v2/screenshots/` before saving
+- **Grafana not running**: Start the stack with `docker-compose up -d` from `v2/`
+- **Empty panels**: Run `npm run seed`; verify `v2-postgres-1` is healthy
+- **Missing directory**: Create `v2/screenshots/` before saving

--- a/.github/skills/safe-worktree/SKILL.md
+++ b/.github/skills/safe-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: safe-worktree
-description: "**WORKFLOW SKILL** — Creates an isolated Git worktree from origin/<default> before any code changes. Fetches remote first to avoid inheriting unpushed local commits. WHEN: \"start any coding task\", \"before making code changes\", \"beginning implementation\", \"autopilot session start\", \"create worktree for task\". INVOKES: git fetch, git worktree add. FOR SINGLE OPERATIONS: use git worktree add directly if already on a clean isolated worktree."
+description: "**WORKFLOW SKILL** — Creates an isolated Git worktree from origin/<default> before any code changes. WHEN: \"start any coding task\", \"before making code changes\", \"beginning implementation\", \"autopilot session start\", \"create worktree for task\". INVOKES: git fetch, git worktree add. FOR SINGLE OPERATIONS: use git worktree add directly if already on a clean isolated worktree."
 ---
 
 # Safe Worktree
@@ -64,3 +64,7 @@ git push -u origin <branch-name>
 ```
 
 Never force-push. If rejected by branch protection, create a new worktree with a different branch name.
+
+## ⚠️ Do NOT open a pull request
+
+Push the branch and stop. **Do not create a pull request** unless the user explicitly asks for one (e.g., "open a PR", "create a pull request"). Opening an unsolicited PR is an overreach — the user decides when and whether to merge.

--- a/v2/grafana/dashboards/00-overview.json
+++ b/v2/grafana/dashboards/00-overview.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -52,7 +52,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -62,7 +62,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -72,7 +72,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -100,7 +100,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/00-overview.json
+++ b/v2/grafana/dashboards/00-overview.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/00-overview.json
+++ b/v2/grafana/dashboards/00-overview.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -64,7 +64,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }

--- a/v2/grafana/dashboards/00-overview.json
+++ b/v2/grafana/dashboards/00-overview.json
@@ -24,7 +24,7 @@
       "id": 10,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -66,16 +66,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/01-deployment-frequency.json
+++ b/v2/grafana/dashboards/01-deployment-frequency.json
@@ -17,7 +17,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -35,7 +35,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -59,16 +59,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/01-deployment-frequency.json
+++ b/v2/grafana/dashboards/01-deployment-frequency.json
@@ -35,7 +35,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/01-deployment-frequency.json
+++ b/v2/grafana/dashboards/01-deployment-frequency.json
@@ -35,7 +35,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -45,7 +45,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -55,7 +55,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -65,7 +65,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -93,7 +93,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/01-deployment-frequency.json
+++ b/v2/grafana/dashboards/01-deployment-frequency.json
@@ -35,7 +35,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -57,7 +57,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }

--- a/v2/grafana/dashboards/02-lead-time.json
+++ b/v2/grafana/dashboards/02-lead-time.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -87,7 +87,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }

--- a/v2/grafana/dashboards/02-lead-time.json
+++ b/v2/grafana/dashboards/02-lead-time.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -75,7 +75,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -85,7 +85,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -95,7 +95,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -123,7 +123,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/02-lead-time.json
+++ b/v2/grafana/dashboards/02-lead-time.json
@@ -47,7 +47,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -89,16 +89,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/02-lead-time.json
+++ b/v2/grafana/dashboards/02-lead-time.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/03-change-failure-rate.json
+++ b/v2/grafana/dashboards/03-change-failure-rate.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -87,7 +87,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }

--- a/v2/grafana/dashboards/03-change-failure-rate.json
+++ b/v2/grafana/dashboards/03-change-failure-rate.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -75,7 +75,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -85,7 +85,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -95,7 +95,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -123,7 +123,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/03-change-failure-rate.json
+++ b/v2/grafana/dashboards/03-change-failure-rate.json
@@ -47,7 +47,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -89,16 +89,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/03-change-failure-rate.json
+++ b/v2/grafana/dashboards/03-change-failure-rate.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/04-mean-time-to-recovery.json
+++ b/v2/grafana/dashboards/04-mean-time-to-recovery.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -87,7 +87,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }

--- a/v2/grafana/dashboards/04-mean-time-to-recovery.json
+++ b/v2/grafana/dashboards/04-mean-time-to-recovery.json
@@ -47,7 +47,7 @@
       "id": 8,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -89,16 +89,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/04-mean-time-to-recovery.json
+++ b/v2/grafana/dashboards/04-mean-time-to-recovery.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -75,7 +75,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -85,7 +85,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -95,7 +95,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -123,7 +123,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/04-mean-time-to-recovery.json
+++ b/v2/grafana/dashboards/04-mean-time-to-recovery.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/05-copilot-adoption.json
+++ b/v2/grafana/dashboards/05-copilot-adoption.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -52,7 +52,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -62,7 +62,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -72,7 +72,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -100,7 +100,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/05-copilot-adoption.json
+++ b/v2/grafana/dashboards/05-copilot-adoption.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/05-copilot-adoption.json
+++ b/v2/grafana/dashboards/05-copilot-adoption.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -64,7 +64,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }

--- a/v2/grafana/dashboards/05-copilot-adoption.json
+++ b/v2/grafana/dashboards/05-copilot-adoption.json
@@ -24,7 +24,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -66,16 +66,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/06-copilot-code-impact.json
+++ b/v2/grafana/dashboards/06-copilot-code-impact.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -52,7 +52,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -62,7 +62,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -72,7 +72,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -100,7 +100,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/06-copilot-code-impact.json
+++ b/v2/grafana/dashboards/06-copilot-code-impact.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/06-copilot-code-impact.json
+++ b/v2/grafana/dashboards/06-copilot-code-impact.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -64,7 +64,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }

--- a/v2/grafana/dashboards/06-copilot-code-impact.json
+++ b/v2/grafana/dashboards/06-copilot-code-impact.json
@@ -24,7 +24,7 @@
       "id": 10,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -66,16 +66,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/07-dora-vs-copilot.json
+++ b/v2/grafana/dashboards/07-dora-vs-copilot.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -87,7 +87,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }

--- a/v2/grafana/dashboards/07-dora-vs-copilot.json
+++ b/v2/grafana/dashboards/07-dora-vs-copilot.json
@@ -47,7 +47,7 @@
       "id": 8,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -89,16 +89,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/07-dora-vs-copilot.json
+++ b/v2/grafana/dashboards/07-dora-vs-copilot.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -75,7 +75,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -85,7 +85,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -95,7 +95,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -123,7 +123,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/07-dora-vs-copilot.json
+++ b/v2/grafana/dashboards/07-dora-vs-copilot.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/08-overview-edu.json
+++ b/v2/grafana/dashboards/08-overview-edu.json
@@ -21,7 +21,7 @@
       "id": 10,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -63,16 +63,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/08-overview-edu.json
+++ b/v2/grafana/dashboards/08-overview-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -61,7 +61,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }
@@ -215,7 +215,8 @@
         "w": 24,
         "x": 0,
         "y": 21
-      }
+      },
+      "description": "Learning guide section for Deployment Frequency."
     },
     {
       "id": 300,
@@ -231,7 +232,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 3,
@@ -323,7 +325,8 @@
         "w": 24,
         "x": 0,
         "y": 28
-      }
+      },
+      "description": "Learning guide section for Lead Time (median hours)."
     },
     {
       "id": 301,
@@ -339,7 +342,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 4,
@@ -431,7 +435,8 @@
         "w": 24,
         "x": 0,
         "y": 35
-      }
+      },
+      "description": "Learning guide section for Change Fail Rate."
     },
     {
       "id": 302,
@@ -447,7 +452,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 5,
@@ -539,7 +545,8 @@
         "w": 24,
         "x": 0,
         "y": 42
-      }
+      },
+      "description": "Learning guide section for MTTR (median)."
     },
     {
       "id": 303,
@@ -555,7 +562,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 6,
@@ -638,7 +646,8 @@
         "w": 24,
         "x": 0,
         "y": 49
-      }
+      },
+      "description": "Learning guide section for Active Copilot Seats."
     },
     {
       "id": 304,
@@ -654,7 +663,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 7,
@@ -746,7 +756,8 @@
         "w": 24,
         "x": 0,
         "y": 56
-      }
+      },
+      "description": "Learning guide section for Acceptance Rate (%)."
     },
     {
       "id": 305,
@@ -762,7 +773,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 8,
@@ -854,7 +866,8 @@
         "w": 24,
         "x": 0,
         "y": 63
-      }
+      },
+      "description": "Learning guide section for Copilot PR Rate (%)."
     },
     {
       "id": 306,
@@ -870,7 +883,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 9,
@@ -953,7 +967,8 @@
         "w": 24,
         "x": 0,
         "y": 70
-      }
+      },
+      "description": "Learning guide section for Lines Accepted (28d)."
     },
     {
       "id": 307,
@@ -969,7 +984,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     }
   ],
   "tags": [

--- a/v2/grafana/dashboards/08-overview-edu.json
+++ b/v2/grafana/dashboards/08-overview-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -49,7 +49,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -59,7 +59,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -69,7 +69,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -97,7 +97,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/08-overview-edu.json
+++ b/v2/grafana/dashboards/08-overview-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/09-deployment-frequency-edu.json
+++ b/v2/grafana/dashboards/09-deployment-frequency-edu.json
@@ -14,7 +14,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner \u2014 shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner \u2014 shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -32,7 +32,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '\ud83d\udce1 Live Data \u2014 ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '\ud83c\udf31 Synthetic Seed Data \u2014 ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '\ud83c\udfae Demo Environment \u2014 ' || COALESCE(source_label, '')\n    ELSE '\u2753 Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '\ud83c\udf31 Synthetic Seed Data'\n    ELSE '\ud83d\udce1 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -59,16 +59,6 @@
                 }
               }
             },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
-                }
-              }
-            }
           ],
           "thresholds": {
             "mode": "absolute",

--- a/v2/grafana/dashboards/09-deployment-frequency-edu.json
+++ b/v2/grafana/dashboards/09-deployment-frequency-edu.json
@@ -58,7 +58,7 @@
                   "index": 1
                 }
               }
-            },
+            }
           ],
           "thresholds": {
             "mode": "absolute",

--- a/v2/grafana/dashboards/09-deployment-frequency-edu.json
+++ b/v2/grafana/dashboards/09-deployment-frequency-edu.json
@@ -32,7 +32,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/09-deployment-frequency-edu.json
+++ b/v2/grafana/dashboards/09-deployment-frequency-edu.json
@@ -32,7 +32,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -42,7 +42,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -52,7 +52,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -62,7 +62,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -90,7 +90,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/09-deployment-frequency-edu.json
+++ b/v2/grafana/dashboards/09-deployment-frequency-edu.json
@@ -6,7 +6,7 @@
   "refresh": "5m",
   "timepicker": {},
   "version": 1,
-  "title": "\ud83d\ude80 Deployment Frequency [Edu] [v2]",
+  "title": "🚀 Deployment Frequency [Edu] [v2]",
   "schemaVersion": 36,
   "uid": "edu-deployment-frequency",
   "panels": [
@@ -14,7 +14,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner \u2014 shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -32,7 +32,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '\ud83d\udce1 Live Data \u2014 ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '\ud83c\udf31 Synthetic Seed Data \u2014 ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '\ud83c\udfae Demo Environment \u2014 ' || COALESCE(source_label, '')\n    ELSE '\u2753 Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -54,7 +54,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }
@@ -110,13 +110,13 @@
       },
       "id": 1,
       "options": {
-        "content": "# \ud83d\ude80 Deployment Frequency\n\n**DORA Pillar: Throughput**\n\n## What it Measures\nDeployment Frequency measures how often your organisation successfully deploys code to production. It is one of the two DORA *throughput* metrics and reflects the pace at which your team delivers value to users.\n\n## Why it Matters\nHigher deployment frequency indicates a mature, well-automated CI/CD pipeline and a team that delivers small, incremental changes. Elite-performing teams deploy on demand (multiple times per day), while low performers deploy less than once per month.\n\n## How to Interpret\n| Performance Level | Frequency | What it Means |\n|---|---|---|\n| \ud83d\udfe2 Elite | Multiple deploys/day (>7/wk) | On-demand delivery, small batch sizes |\n| \ud83d\udfe1 High | 1\u20137 deploys/week | Regular cadence, good automation |\n| \ud83d\udfe0 Medium | 1\u20134 deploys/month (<1/wk) | Larger batches, some manual steps |\n| \ud83d\udd34 Low | <1 deploy/month (<0.25/wk) | Infrequent releases, high risk per deploy |",
+        "content": "# 🚀 Deployment Frequency\n\n**DORA Pillar: Throughput**\n\n## What it Measures\nDeployment Frequency measures how often your organisation successfully deploys code to production. It is one of the two DORA *throughput* metrics and reflects the pace at which your team delivers value to users.\n\n## Why it Matters\nHigher deployment frequency indicates a mature, well-automated CI/CD pipeline and a team that delivers small, incremental changes. Elite-performing teams deploy on demand (multiple times per day), while low performers deploy less than once per month.\n\n## How to Interpret\n| Performance Level | Frequency | What it Means |\n|---|---|---|\n| 🟢 Elite | Multiple deploys/day (>7/wk) | On-demand delivery, small batch sizes |\n| 🟡 High | 1–7 deploys/week | Regular cadence, good automation |\n| 🟠 Medium | 1–4 deploys/month (<1/wk) | Larger batches, some manual steps |\n| 🔴 Low | <1 deploy/month (<0.25/wk) | Infrequent releases, high risk per deploy |",
         "mode": "markdown"
       },
       "title": "",
       "type": "text",
       "transparent": true,
-      "description": "Deployment Frequency \u2014 DORA throughput pillar. Performance tiers and action guidance."
+      "description": "Deployment Frequency — DORA throughput pillar. Performance tiers and action guidance."
     },
     {
       "datasource": {
@@ -199,7 +199,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `GET /repos/{owner}/{repo}/deployments/{id}/statuses`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### \ud83d\udcd0 How It's Calculated\n\nCounts distinct successful deployments divided by the number of weeks in the selected time window.\n### \u26a0\ufe0f Calculation Challenges\n\n- **GitHub-native only** \u2014 deployments via ArgoCD, Jenkins, or other tools not integrated with the GitHub Deployments API are invisible to this metric.\n- **Environment field is free-text** \u2014 'production', 'prod', and 'PROD' count as separate environments unless normalized.\n- **Success state is caller-set** \u2014 the deployer marks a deployment 'success'; GitHub does not independently verify it.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Whether deployed code is actually healthy in production.\n- Deployments that bypassed the GitHub Deployments API entirely.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nSELECT COUNT(DISTINCT d.deployment_id)::float / GREATEST(1, EXTRACT(DAY FROM ($__timeTo()::timestamptz - $__timeFrom()::timestamptz)) / 7.0) AS \"Deployments/Week\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\nAND ds.state = 'success'\nAND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `GET /repos/{owner}/{repo}/deployments/{id}/statuses`\n\n### 🗄️ Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### 📐 How It's Calculated\n\nCounts distinct successful deployments divided by the number of weeks in the selected time window.\n### ⚠️ Calculation Challenges\n\n- **GitHub-native only** — deployments via ArgoCD, Jenkins, or other tools not integrated with the GitHub Deployments API are invisible to this metric.\n- **Environment field is free-text** — 'production', 'prod', and 'PROD' count as separate environments unless normalized.\n- **Success state is caller-set** — the deployer marks a deployment 'success'; GitHub does not independently verify it.\n### 💡 What This Metric Doesn't Tell You\n\n- Whether deployed code is actually healthy in production.\n- Deployments that bypassed the GitHub Deployments API entirely.\n\n### 🔍 SQL Query\n\n```sql\nSELECT COUNT(DISTINCT d.deployment_id)::float / GREATEST(1, EXTRACT(DAY FROM ($__timeTo()::timestamptz - $__timeFrom()::timestamptz)) / 7.0) AS \"Deployments/Week\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\nAND ds.state = 'success'\nAND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n```"
           }
         }
       ],
@@ -208,7 +208,8 @@
         "w": 24,
         "x": 0,
         "y": 21
-      }
+      },
+      "description": "Learning guide section for Deployment Frequency."
     },
     {
       "id": 300,
@@ -224,7 +225,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "datasource": {
@@ -307,7 +309,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments/{id}/statuses`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### \ud83d\udcd0 How It's Calculated\n\nRatio of deployments with at least one 'success' status to total deployments. Uses NULLIF to prevent division by zero.\n### \u26a0\ufe0f Calculation Challenges\n\n- **State is caller-set** \u2014 the deployer marks the deployment state; it is not independently verified by GitHub.\n- **Deployments with no status rows** \u2014 a deployment created but never given a status ('pending') is in the denominator but never the numerator, deflating success rate.\n- **Multiple status rows per deployment** \u2014 the query counts distinct deployment IDs with state='success', not individual status rows.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Post-deployment health or application availability.\n- Partial failures (deploy succeeded but a feature flag is off, etc.).\n\n### \ud83d\udd0d SQL Query\n\n```sql\nSELECT ROUND(\n  COUNT(DISTINCT CASE WHEN ds.state = 'success' THEN d.deployment_id END)::numeric * 100.0\n  / NULLIF(COUNT(DISTINCT d.deployment_id), 0), 1\n) AS \"Success Rate (%)\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments/{id}/statuses`\n\n### 🗄️ Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### 📐 How It's Calculated\n\nRatio of deployments with at least one 'success' status to total deployments. Uses NULLIF to prevent division by zero.\n### ⚠️ Calculation Challenges\n\n- **State is caller-set** — the deployer marks the deployment state; it is not independently verified by GitHub.\n- **Deployments with no status rows** — a deployment created but never given a status ('pending') is in the denominator but never the numerator, deflating success rate.\n- **Multiple status rows per deployment** — the query counts distinct deployment IDs with state='success', not individual status rows.\n### 💡 What This Metric Doesn't Tell You\n\n- Post-deployment health or application availability.\n- Partial failures (deploy succeeded but a feature flag is off, etc.).\n\n### 🔍 SQL Query\n\n```sql\nSELECT ROUND(\n  COUNT(DISTINCT CASE WHEN ds.state = 'success' THEN d.deployment_id END)::numeric * 100.0\n  / NULLIF(COUNT(DISTINCT d.deployment_id), 0), 1\n) AS \"Success Rate (%)\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n```"
           }
         }
       ],
@@ -316,7 +318,8 @@
         "w": 24,
         "x": 0,
         "y": 28
-      }
+      },
+      "description": "Learning guide section for Deployment Success Rate."
     },
     {
       "id": 301,
@@ -332,7 +335,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "datasource": {
@@ -398,7 +402,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `/deployments/{id}/statuses`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### \ud83d\udcd0 How It's Calculated\n\nTime series bucketed by week using date_trunc('week', created_at). Counts distinct successful deployment IDs per week.\n### \u26a0\ufe0f Calculation Challenges\n\n- **date_trunc('week') starts on Monday** \u2014 a deployment on Sunday falls into the previous week bucket, which can misalign with sprint reporting.\n- **created_at, not finished_at** \u2014 timestamps reflect deployment creation, not completion or marking as successful.\n- **Zero-deployment weeks are gaps** \u2014 Grafana shows a line gap for weeks with no deployments (no zero-fill in the SQL result set).\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Deployment duration or rollback rates.\n- Whether deploys targeted production or lower environments.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nSELECT\n  date_trunc('week', d.created_at) AS time,\n  COUNT(DISTINCT d.deployment_id) AS \"Deployments\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND ds.state = 'success'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `/deployments/{id}/statuses`\n\n### 🗄️ Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### 📐 How It's Calculated\n\nTime series bucketed by week using date_trunc('week', created_at). Counts distinct successful deployment IDs per week.\n### ⚠️ Calculation Challenges\n\n- **date_trunc('week') starts on Monday** — a deployment on Sunday falls into the previous week bucket, which can misalign with sprint reporting.\n- **created_at, not finished_at** — timestamps reflect deployment creation, not completion or marking as successful.\n- **Zero-deployment weeks are gaps** — Grafana shows a line gap for weeks with no deployments (no zero-fill in the SQL result set).\n### 💡 What This Metric Doesn't Tell You\n\n- Deployment duration or rollback rates.\n- Whether deploys targeted production or lower environments.\n\n### 🔍 SQL Query\n\n```sql\nSELECT\n  date_trunc('week', d.created_at) AS time,\n  COUNT(DISTINCT d.deployment_id) AS \"Deployments\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND ds.state = 'success'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 1\n```"
           }
         }
       ],
@@ -407,7 +411,8 @@
         "w": 24,
         "x": 0,
         "y": 39
-      }
+      },
+      "description": "Learning guide section for Deployments per Week."
     },
     {
       "id": 302,
@@ -423,7 +428,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "datasource": {
@@ -485,7 +491,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### \ud83d\udcd0 How It's Calculated\n\nBar chart grouped by the environment field from the deployments table, filtered to successful deployments in the time window.\n### \u26a0\ufe0f Calculation Challenges\n\n- **Free-text environment names** \u2014 'production', 'prod', 'PROD', and 'Production' are four separate environments with no canonical mapping.\n- **No environment hierarchy** \u2014 staging and production are treated equally; there is no parent-child relationship.\n- **Only GitHub-native deploys** \u2014 external CD tools without GitHub Deployment API integration are absent.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Which environments are production-equivalent.\n- Traffic or criticality weighting of each environment.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nSELECT\n  d.environment AS \"Environment\",\n  COUNT(DISTINCT d.deployment_id) AS \"Deployments\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ds.state = 'success'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 2 DESC\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments`\n\n### 🗄️ Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### 📐 How It's Calculated\n\nBar chart grouped by the environment field from the deployments table, filtered to successful deployments in the time window.\n### ⚠️ Calculation Challenges\n\n- **Free-text environment names** — 'production', 'prod', 'PROD', and 'Production' are four separate environments with no canonical mapping.\n- **No environment hierarchy** — staging and production are treated equally; there is no parent-child relationship.\n- **Only GitHub-native deploys** — external CD tools without GitHub Deployment API integration are absent.\n### 💡 What This Metric Doesn't Tell You\n\n- Which environments are production-equivalent.\n- Traffic or criticality weighting of each environment.\n\n### 🔍 SQL Query\n\n```sql\nSELECT\n  d.environment AS \"Environment\",\n  COUNT(DISTINCT d.deployment_id) AS \"Deployments\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ds.state = 'success'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 2 DESC\n```"
           }
         }
       ],
@@ -494,7 +500,8 @@
         "w": 24,
         "x": 0,
         "y": 50
-      }
+      },
+      "description": "Learning guide section for Deployments by Environment."
     },
     {
       "id": 303,
@@ -510,7 +517,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "datasource": {
@@ -580,7 +588,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments/{id}/statuses`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### \ud83d\udcd0 How It's Calculated\n\nWeekly count of deployments where any status row has state='failure'.\n### \u26a0\ufe0f Calculation Challenges\n\n- **'failure' vs 'error'** \u2014 the API distinguishes 'failure' (deploy ran but failed) from 'error' (deploy couldn't start). This query only captures 'failure'.\n- **Retry artifacts** \u2014 a failed-then-retried deployment appears in both failure and success counts.\n- **No root cause** \u2014 the API captures the state transition only; failure reason must be retrieved from CI logs separately.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Why deployments failed.\n- Which service or component caused the failure.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nSELECT\n  date_trunc('week', d.created_at) AS time,\n  COUNT(DISTINCT d.deployment_id) AS \"Failed Deployments\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND ds.state = 'failure'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments/{id}/statuses`\n\n### 🗄️ Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### 📐 How It's Calculated\n\nWeekly count of deployments where any status row has state='failure'.\n### ⚠️ Calculation Challenges\n\n- **'failure' vs 'error'** — the API distinguishes 'failure' (deploy ran but failed) from 'error' (deploy couldn't start). This query only captures 'failure'.\n- **Retry artifacts** — a failed-then-retried deployment appears in both failure and success counts.\n- **No root cause** — the API captures the state transition only; failure reason must be retrieved from CI logs separately.\n### 💡 What This Metric Doesn't Tell You\n\n- Why deployments failed.\n- Which service or component caused the failure.\n\n### 🔍 SQL Query\n\n```sql\nSELECT\n  date_trunc('week', d.created_at) AS time,\n  COUNT(DISTINCT d.deployment_id) AS \"Failed Deployments\"\nFROM deployments d\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND ds.state = 'failure'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 1\n```"
           }
         }
       ],
@@ -589,7 +597,8 @@
         "w": 24,
         "x": 0,
         "y": 61
-      }
+      },
+      "description": "Learning guide section for Failed Deployments Timeline."
     },
     {
       "id": 304,
@@ -605,7 +614,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "datasource": {
@@ -665,7 +675,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `/deployments/{id}/statuses`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### \ud83d\udcd0 How It's Calculated\n\nTable showing raw deployment records with their latest status. Uses LEFT JOIN so deployments with no status are still shown.\n### \u26a0\ufe0f Calculation Challenges\n\n- **LEFT JOIN shows only latest status** \u2014 if a deployment has multiple status transitions, only the most-recent row is visible in the join.\n- **SHA is the raw 40-char commit SHA** \u2014 no branch name or PR link is included in this view; bridge resolver data is not joined here.\n- **creator_login is the API caller** \u2014 this is whoever triggered the deployment via the API (often a bot), not necessarily the developer whose code is deployed.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Which PR or branch was deployed.\n- Whether a deployment was a rollback or a new feature.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nSELECT\n  d.sha,\n  d.environment,\n  ds.state AS status,\n  d.creator_login,\n  d.created_at\nFROM deployments d\nLEFT JOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nORDER BY d.created_at DESC\nLIMIT 50\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `/deployments/{id}/statuses`\n\n### 🗄️ Database Table(s)\n\n`deployments`, `deployment_statuses`\n\n### 📐 How It's Calculated\n\nTable showing raw deployment records with their latest status. Uses LEFT JOIN so deployments with no status are still shown.\n### ⚠️ Calculation Challenges\n\n- **LEFT JOIN shows only latest status** — if a deployment has multiple status transitions, only the most-recent row is visible in the join.\n- **SHA is the raw 40-char commit SHA** — no branch name or PR link is included in this view; bridge resolver data is not joined here.\n- **creator_login is the API caller** — this is whoever triggered the deployment via the API (often a bot), not necessarily the developer whose code is deployed.\n### 💡 What This Metric Doesn't Tell You\n\n- Which PR or branch was deployed.\n- Whether a deployment was a rollback or a new feature.\n\n### 🔍 SQL Query\n\n```sql\nSELECT\n  d.sha,\n  d.environment,\n  ds.state AS status,\n  d.creator_login,\n  d.created_at\nFROM deployments d\nLEFT JOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nORDER BY d.created_at DESC\nLIMIT 50\n```"
           }
         }
       ],
@@ -674,7 +684,8 @@
         "w": 24,
         "x": 0,
         "y": 72
-      }
+      },
+      "description": "Learning guide section for Recent Deployments."
     },
     {
       "id": 305,
@@ -690,7 +701,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "datasource": {
@@ -752,7 +764,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `GET /orgs/{org}/copilot/seats`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `deployment_pull_requests`, `pull_requests`, `deployment_statuses`, `copilot_seats`\n\n### \ud83d\udcd0 How It's Calculated\n\nSplits weekly deployments by whether the linked PR's author (`user_id`) has an active Copilot seat. Each deployment is joined to its source PR via `deployment_pull_requests`, and then to `copilot_seats` via `pr.user_id = cu.assignee_id`. Built with a WITH copilot_users CTE.\n### \u26a0\ufe0f Calculation Challenges\n\n- **Attribution by PR author, not deployer** \u2014 cohort split uses the PR author's `user_id`, not `creator_login` (who triggered the deployment API). Deployments without a linked PR are excluded entirely.\n- **Fixed 28-day seat window** \u2014 the CTE uses NOW()-28d regardless of your Grafana time range. Historical comparisons always use the current seat roster.\n- **Correlation only** \u2014 teams using Copilot may differ in many ways from those who don't.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Whether Copilot was used in any specific deployment.\n- Causality between Copilot adoption and deployment frequency.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  date_trunc('week', d.created_at) AS time,\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  COUNT(DISTINCT d.deployment_id) AS \"Deployments\"\nFROM deployments d\nJOIN deployment_pull_requests dpr ON dpr.deployment_id = d.deployment_id\nJOIN pull_requests pr ON pr.number = dpr.pr_number\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND ds.state = 'success'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `GET /orgs/{org}/copilot/seats`\n\n### 🗄️ Database Table(s)\n\n`deployments`, `deployment_pull_requests`, `pull_requests`, `deployment_statuses`, `copilot_seats`\n\n### 📐 How It's Calculated\n\nSplits weekly deployments by whether the linked PR's author (`user_id`) has an active Copilot seat. Each deployment is joined to its source PR via `deployment_pull_requests`, and then to `copilot_seats` via `pr.user_id = cu.assignee_id`. Built with a WITH copilot_users CTE.\n### ⚠️ Calculation Challenges\n\n- **Attribution by PR author, not deployer** — cohort split uses the PR author's `user_id`, not `creator_login` (who triggered the deployment API). Deployments without a linked PR are excluded entirely.\n- **Fixed 28-day seat window** — the CTE uses NOW()-28d regardless of your Grafana time range. Historical comparisons always use the current seat roster.\n- **Correlation only** — teams using Copilot may differ in many ways from those who don't.\n### 💡 What This Metric Doesn't Tell You\n\n- Whether Copilot was used in any specific deployment.\n- Causality between Copilot adoption and deployment frequency.\n\n### 🔍 SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  date_trunc('week', d.created_at) AS time,\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  COUNT(DISTINCT d.deployment_id) AS \"Deployments\"\nFROM deployments d\nJOIN deployment_pull_requests dpr ON dpr.deployment_id = d.deployment_id\nJOIN pull_requests pr ON pr.number = dpr.pr_number\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE ('$environment' = '__all__' OR d.environment = '$environment')\n  AND ds.state = 'success'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1\n```"
           }
         }
       ],
@@ -761,7 +773,8 @@
         "w": 24,
         "x": 0,
         "y": 83
-      }
+      },
+      "description": "Learning guide section for Deployment Frequency: Copilot vs Non-Copilot."
     },
     {
       "id": 306,
@@ -777,7 +790,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     }
   ],
   "templating": {
@@ -806,7 +820,7 @@
       }
     ]
   },
-  "description": "DORA Pillar: Deployment Frequency \u2014 Measures how often code is successfully deployed. Elite teams deploy multiple times per day.",
+  "description": "DORA Pillar: Deployment Frequency — Measures how often code is successfully deployed. Elite teams deploy multiple times per day.",
   "tags": [
     "dora",
     "edu"

--- a/v2/grafana/dashboards/10-lead-time-edu.json
+++ b/v2/grafana/dashboards/10-lead-time-edu.json
@@ -44,7 +44,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -86,16 +86,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/10-lead-time-edu.json
+++ b/v2/grafana/dashboards/10-lead-time-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -72,7 +72,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -82,7 +82,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -92,7 +92,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -120,7 +120,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/10-lead-time-edu.json
+++ b/v2/grafana/dashboards/10-lead-time-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -84,7 +84,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }
@@ -238,7 +238,8 @@
         "w": 24,
         "x": 0,
         "y": 21
-      }
+      },
+      "description": "Learning guide section for Change Lead Time (median hours)."
     },
     {
       "id": 300,
@@ -254,7 +255,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 3,
@@ -346,7 +348,8 @@
         "w": 24,
         "x": 0,
         "y": 28
-      }
+      },
+      "description": "Learning guide section for PR Cycle Time (median hours)."
     },
     {
       "id": 301,
@@ -362,7 +365,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 4,
@@ -454,7 +458,8 @@
         "w": 24,
         "x": 0,
         "y": 35
-      }
+      },
+      "description": "Learning guide section for P90 Lead Time (hours)."
     },
     {
       "id": 302,
@@ -470,7 +475,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 5,
@@ -545,7 +551,8 @@
         "w": 24,
         "x": 0,
         "y": 46
-      }
+      },
+      "description": "Learning guide section for Change Lead Time over Time."
     },
     {
       "id": 303,
@@ -561,7 +568,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 6,
@@ -636,7 +644,8 @@
         "w": 24,
         "x": 0,
         "y": 57
-      }
+      },
+      "description": "Learning guide section for PR Cycle Time over Time."
     },
     {
       "id": 304,
@@ -652,7 +661,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 7,
@@ -721,7 +731,8 @@
         "w": 24,
         "x": 0,
         "y": 68
-      }
+      },
+      "description": "Learning guide section for Slowest PRs by Lead Time."
     },
     {
       "id": 305,
@@ -737,7 +748,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 8,
@@ -808,7 +820,8 @@
         "w": 24,
         "x": 0,
         "y": 79
-      }
+      },
+      "description": "Learning guide section for Lead Time: Copilot vs Non-Copilot."
     },
     {
       "id": 306,
@@ -824,7 +837,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     }
   ],
   "tags": [

--- a/v2/grafana/dashboards/10-lead-time-edu.json
+++ b/v2/grafana/dashboards/10-lead-time-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/11-change-failure-rate-edu.json
+++ b/v2/grafana/dashboards/11-change-failure-rate-edu.json
@@ -44,7 +44,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -86,16 +86,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/11-change-failure-rate-edu.json
+++ b/v2/grafana/dashboards/11-change-failure-rate-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -72,7 +72,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -82,7 +82,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -92,7 +92,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -120,7 +120,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/11-change-failure-rate-edu.json
+++ b/v2/grafana/dashboards/11-change-failure-rate-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -84,7 +84,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }
@@ -238,7 +238,8 @@
         "w": 24,
         "x": 0,
         "y": 21
-      }
+      },
+      "description": "Learning guide section for Change Fail Rate (%)."
     },
     {
       "id": 300,
@@ -254,7 +255,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 3,
@@ -346,7 +348,8 @@
         "w": 24,
         "x": 0,
         "y": 28
-      }
+      },
+      "description": "Learning guide section for Deployment Rework Rate (%)."
     },
     {
       "id": 301,
@@ -362,7 +365,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 4,
@@ -453,7 +457,8 @@
         "w": 24,
         "x": 0,
         "y": 35
-      }
+      },
+      "description": "Learning guide section for Total Incidents."
     },
     {
       "id": 302,
@@ -469,7 +474,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 5,
@@ -544,7 +550,8 @@
         "w": 24,
         "x": 0,
         "y": 46
-      }
+      },
+      "description": "Learning guide section for Change Fail Rate over Time."
     },
     {
       "id": 303,
@@ -560,7 +567,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 6,
@@ -639,7 +647,8 @@
         "w": 24,
         "x": 0,
         "y": 57
-      }
+      },
+      "description": "Learning guide section for Incidents over Time."
     },
     {
       "id": 304,
@@ -655,7 +664,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 7,
@@ -724,7 +734,8 @@
         "w": 24,
         "x": 0,
         "y": 68
-      }
+      },
+      "description": "Learning guide section for Open Incidents."
     },
     {
       "id": 305,
@@ -740,7 +751,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 8,
@@ -811,7 +823,8 @@
         "w": 24,
         "x": 0,
         "y": 79
-      }
+      },
+      "description": "Learning guide section for CFR: Copilot vs Non-Copilot."
     },
     {
       "id": 306,
@@ -827,7 +840,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     }
   ],
   "tags": [

--- a/v2/grafana/dashboards/11-change-failure-rate-edu.json
+++ b/v2/grafana/dashboards/11-change-failure-rate-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
+++ b/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
@@ -44,7 +44,7 @@
       "id": 8,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -86,16 +86,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
+++ b/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -84,7 +84,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }
@@ -238,7 +238,8 @@
         "w": 24,
         "x": 0,
         "y": 21
-      }
+      },
+      "description": "Learning guide section for MTTR (median)."
     },
     {
       "id": 300,
@@ -254,7 +255,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 3,
@@ -346,7 +348,8 @@
         "w": 24,
         "x": 0,
         "y": 28
-      }
+      },
+      "description": "Learning guide section for P90 MTTR (hours)."
     },
     {
       "id": 301,
@@ -362,7 +365,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 4,
@@ -453,7 +457,8 @@
         "w": 24,
         "x": 0,
         "y": 35
-      }
+      },
+      "description": "Learning guide section for Incidents Still Open."
     },
     {
       "id": 302,
@@ -469,7 +474,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 5,
@@ -544,7 +550,8 @@
         "w": 24,
         "x": 0,
         "y": 46
-      }
+      },
+      "description": "Learning guide section for MTTR over Time."
     },
     {
       "id": 303,
@@ -560,7 +567,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 6,
@@ -635,7 +643,8 @@
         "w": 24,
         "x": 0,
         "y": 57
-      }
+      },
+      "description": "Learning guide section for Incident Resolution Time."
     },
     {
       "id": 304,
@@ -651,7 +660,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 7,
@@ -720,7 +730,8 @@
         "w": 24,
         "x": 0,
         "y": 68
-      }
+      },
+      "description": "Learning guide section for Recent Failures with Recovery Time."
     },
     {
       "id": 305,
@@ -736,7 +747,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     }
   ],
   "tags": [

--- a/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
+++ b/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -72,7 +72,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -82,7 +82,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -92,7 +92,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -120,7 +120,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
+++ b/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/13-copilot-adoption-edu.json
+++ b/v2/grafana/dashboards/13-copilot-adoption-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -49,7 +49,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -59,7 +59,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -69,7 +69,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -97,7 +97,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/13-copilot-adoption-edu.json
+++ b/v2/grafana/dashboards/13-copilot-adoption-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/13-copilot-adoption-edu.json
+++ b/v2/grafana/dashboards/13-copilot-adoption-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -61,7 +61,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }
@@ -206,7 +206,8 @@
         "w": 24,
         "x": 0,
         "y": 21
-      }
+      },
+      "description": "Learning guide section for Total Seats."
     },
     {
       "id": 300,
@@ -222,7 +223,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 3,
@@ -305,7 +307,8 @@
         "w": 24,
         "x": 0,
         "y": 28
-      }
+      },
+      "description": "Learning guide section for Active Seats (28d)."
     },
     {
       "id": 301,
@@ -321,7 +324,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 4,
@@ -413,7 +417,8 @@
         "w": 24,
         "x": 0,
         "y": 35
-      }
+      },
+      "description": "Learning guide section for Seat Utilization Rate (%)."
     },
     {
       "id": 302,
@@ -429,7 +434,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 5,
@@ -520,7 +526,8 @@
         "w": 24,
         "x": 0,
         "y": 42
-      }
+      },
+      "description": "Learning guide section for Inactive Seats (>14d)."
     },
     {
       "id": 303,
@@ -536,7 +543,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 6,
@@ -611,7 +619,8 @@
         "w": 24,
         "x": 0,
         "y": 53
-      }
+      },
+      "description": "Learning guide section for Daily Active Users."
     },
     {
       "id": 304,
@@ -627,7 +636,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 7,
@@ -698,7 +708,8 @@
         "w": 24,
         "x": 0,
         "y": 64
-      }
+      },
+      "description": "Learning guide section for Last Active Editor Distribution."
     },
     {
       "id": 305,
@@ -714,7 +725,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 8,
@@ -783,7 +795,8 @@
         "w": 24,
         "x": 0,
         "y": 75
-      }
+      },
+      "description": "Learning guide section for Seat Activity Recency."
     },
     {
       "id": 306,
@@ -799,7 +812,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 10,
@@ -890,7 +904,8 @@
         "w": 24,
         "x": 0,
         "y": 82
-      }
+      },
+      "description": "Learning guide section for Copilot Seats Loaded."
     },
     {
       "id": 307,
@@ -906,7 +921,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 11,
@@ -993,7 +1009,8 @@
         "w": 24,
         "x": 0,
         "y": 89
-      }
+      },
+      "description": "Learning guide section for Last Successful Sync."
     },
     {
       "id": 308,
@@ -1009,7 +1026,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     }
   ],
   "tags": [

--- a/v2/grafana/dashboards/13-copilot-adoption-edu.json
+++ b/v2/grafana/dashboards/13-copilot-adoption-edu.json
@@ -21,7 +21,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -63,16 +63,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/14-copilot-code-impact-edu.json
+++ b/v2/grafana/dashboards/14-copilot-code-impact-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -61,7 +61,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }
@@ -206,7 +206,8 @@
         "w": 24,
         "x": 0,
         "y": 21
-      }
+      },
+      "description": "Learning guide section for Lines Accepted (28d)."
     },
     {
       "id": 300,
@@ -222,7 +223,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 3,
@@ -305,7 +307,8 @@
         "w": 24,
         "x": 0,
         "y": 28
-      }
+      },
+      "description": "Learning guide section for Lines Suggested (28d)."
     },
     {
       "id": 301,
@@ -321,7 +324,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 4,
@@ -413,7 +417,8 @@
         "w": 24,
         "x": 0,
         "y": 35
-      }
+      },
+      "description": "Learning guide section for Acceptance Rate (%)."
     },
     {
       "id": 302,
@@ -429,7 +434,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 5,
@@ -512,7 +518,8 @@
         "w": 24,
         "x": 0,
         "y": 42
-      }
+      },
+      "description": "Learning guide section for Copilot-Attributed PRs."
     },
     {
       "id": 303,
@@ -528,7 +535,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 6,
@@ -603,7 +611,8 @@
         "w": 24,
         "x": 0,
         "y": 53
-      }
+      },
+      "description": "Learning guide section for Lines Accepted vs Suggested over Time."
     },
     {
       "id": 304,
@@ -619,7 +628,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 7,
@@ -694,7 +704,8 @@
         "w": 24,
         "x": 0,
         "y": 64
-      }
+      },
+      "description": "Learning guide section for Acceptance Rate Trend."
     },
     {
       "id": 305,
@@ -710,7 +721,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 8,
@@ -802,7 +814,8 @@
         "w": 24,
         "x": 0,
         "y": 71
-      }
+      },
+      "description": "Learning guide section for Copilot PR Rate (%)."
     },
     {
       "id": 306,
@@ -818,7 +831,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 9,
@@ -887,7 +901,8 @@
         "w": 24,
         "x": 0,
         "y": 82
-      }
+      },
+      "description": "Learning guide section for Top 10 by Lines Added (Copilot Users)."
     },
     {
       "id": 307,
@@ -903,7 +918,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 11,
@@ -994,7 +1010,8 @@
         "w": 24,
         "x": 0,
         "y": 89
-      }
+      },
+      "description": "Learning guide section for Copilot Seats Loaded."
     },
     {
       "id": 308,
@@ -1010,7 +1027,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 12,
@@ -1097,7 +1115,8 @@
         "w": 24,
         "x": 0,
         "y": 96
-      }
+      },
+      "description": "Learning guide section for Last Successful Sync."
     },
     {
       "id": 309,
@@ -1113,7 +1132,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     }
   ],
   "tags": [

--- a/v2/grafana/dashboards/14-copilot-code-impact-edu.json
+++ b/v2/grafana/dashboards/14-copilot-code-impact-edu.json
@@ -21,7 +21,7 @@
       "id": 10,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '📡 Live Data — ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '🎮 Demo Environment — ' || COALESCE(source_label, '')\n    ELSE '❓ Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -63,16 +63,6 @@
                 "result": {
                   "color": "#FA6400",
                   "index": 1
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
                 }
               }
             }

--- a/v2/grafana/dashboards/14-copilot-code-impact-edu.json
+++ b/v2/grafana/dashboards/14-copilot-code-impact-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -49,7 +49,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -59,7 +59,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -69,7 +69,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -97,7 +97,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/14-copilot-code-impact-edu.json
+++ b/v2/grafana/dashboards/14-copilot-code-impact-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
+++ b/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
@@ -1,6 +1,6 @@
 {
   "uid": "edu-dora-vs-copilot",
-  "title": "\ud83d\udd2c DORA \u00d7 Copilot [Edu] [v2]",
+  "title": "🔬 DORA × Copilot [Edu] [v2]",
   "description": "Cross-analysis of DORA engineering metrics segmented by Copilot adoption cohort, revealing the impact of AI assistance on software delivery performance.",
   "schemaVersion": 36,
   "version": 1,
@@ -43,7 +43,7 @@
       "id": 8,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner \u2014 shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -61,7 +61,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '\ud83d\udce1 Live Data \u2014 ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '\ud83c\udf31 Synthetic Seed Data \u2014 ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '\ud83c\udfae Demo Environment \u2014 ' || COALESCE(source_label, '')\n    ELSE '\u2753 Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],
@@ -83,7 +83,7 @@
               "options": {
                 "pattern": "Seed Data",
                 "result": {
-                  "color": "#FA6400",
+                  "color": "#FF9830",
                   "index": 1
                 }
               }
@@ -142,10 +142,10 @@
       },
       "options": {
         "mode": "markdown",
-        "content": "# \ud83d\udd2c DORA \u00d7 Copilot Cohort\n\n**Supplementary Metrics \u2014 Copilot impact on DORA performance**\n\n## What it Shows\nThis dashboard compares the four DORA metrics side-by-side for two cohorts: developers with an active Copilot seat versus those without. It surfaces whether Copilot usage correlates with faster lead times, more frequent deployments, or lower failure rates.\n\n## Why it Matters\nCohort comparisons provide the strongest available signal (short of a controlled experiment) for Copilot's impact on engineering velocity and quality. If Copilot-active developers consistently show better DORA scores, it strengthens the case for broader adoption and investment.\n\n> \u26a0\ufe0f **Attribution caveat**: Cohort membership is determined by active seat status (last activity within 28 days) \u2014 not by confirmed Copilot use on specific PRs. Selection bias may exist if higher-performing developers are also more likely to adopt new tools.\n\n## How to Interpret\n- **Lead Time / Cycle Time**: Lower values for Copilot cohort suggest faster code delivery\n- **PR throughput**: Higher weekly PR counts for Copilot cohort indicate productivity gains\n- **Lines changed**: More lines per developer in Copilot cohort may reflect reduced friction writing code"
+        "content": "# 🔬 DORA × Copilot Cohort\n\n**Supplementary Metrics — Copilot impact on DORA performance**\n\n## What it Shows\nThis dashboard compares the four DORA metrics side-by-side for two cohorts: developers with an active Copilot seat versus those without. It surfaces whether Copilot usage correlates with faster lead times, more frequent deployments, or lower failure rates.\n\n## Why it Matters\nCohort comparisons provide the strongest available signal (short of a controlled experiment) for Copilot's impact on engineering velocity and quality. If Copilot-active developers consistently show better DORA scores, it strengthens the case for broader adoption and investment.\n\n> ⚠️ **Attribution caveat**: Cohort membership is determined by active seat status (last activity within 28 days) — not by confirmed Copilot use on specific PRs. Selection bias may exist if higher-performing developers are also more likely to adopt new tools.\n\n## How to Interpret\n- **Lead Time / Cycle Time**: Lower values for Copilot cohort suggest faster code delivery\n- **PR throughput**: Higher weekly PR counts for Copilot cohort indicate productivity gains\n- **Lines changed**: More lines per developer in Copilot cohort may reflect reduced friction writing code"
       },
       "transparent": true,
-      "description": "DORA \u00d7 Copilot Cohort \u2014 compares DORA metrics between Copilot-active and non-active developers."
+      "description": "DORA × Copilot Cohort — compares DORA metrics between Copilot-active and non-active developers."
     },
     {
       "id": 2,
@@ -207,7 +207,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/pulls/pulls)\n\n`GET /repos/{owner}/{repo}/pulls` + bridge resolver + `GET /orgs/{org}/copilot/seats`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`pull_requests`, `deployment_pull_requests`, `deployments`, `copilot_seats`\n\n### \ud83d\udcd0 How It's Calculated\n\nBar chart comparing median lead time for 'Copilot Active' vs 'Non-Copilot' PR authors. Built with a WITH copilot_users CTE.\n### \u26a0\ufe0f Calculation Challenges\n\n- **copilot_users CTE** \u2014 defined as SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'. This is always a fixed 28-day window, not your Grafana time range.\n- **Bridge resolver required** \u2014 only PRs linked to deployments are included; unlinked PRs don't contribute to either cohort's lead time.\n- **Selection bias** \u2014 senior developers often get Copilot seats first; their faster lead times may reflect experience, not AI assistance.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Statistical significance of the lead time difference.\n- Causality \u2014 this is observational; many confounders exist.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (d.created_at - pr.merged_at)) / 3600.0\n  )::numeric, 1) AS \"Lead Time (hours)\"\nFROM deployments d\nJOIN deployment_pull_requests dpr ON dpr.deployment_id = d.deployment_id\nJOIN pull_requests pr ON pr.number = dpr.pr_number\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE d.environment = '$environment'\n  AND ds.state = 'success'\n  AND pr.merged_at IS NOT NULL\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/pulls/pulls)\n\n`GET /repos/{owner}/{repo}/pulls` + bridge resolver + `GET /orgs/{org}/copilot/seats`\n\n### 🗄️ Database Table(s)\n\n`pull_requests`, `deployment_pull_requests`, `deployments`, `copilot_seats`\n\n### 📐 How It's Calculated\n\nBar chart comparing median lead time for 'Copilot Active' vs 'Non-Copilot' PR authors. Built with a WITH copilot_users CTE.\n### ⚠️ Calculation Challenges\n\n- **copilot_users CTE** — defined as SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'. This is always a fixed 28-day window, not your Grafana time range.\n- **Bridge resolver required** — only PRs linked to deployments are included; unlinked PRs don't contribute to either cohort's lead time.\n- **Selection bias** — senior developers often get Copilot seats first; their faster lead times may reflect experience, not AI assistance.\n### 💡 What This Metric Doesn't Tell You\n\n- Statistical significance of the lead time difference.\n- Causality — this is observational; many confounders exist.\n\n### 🔍 SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (d.created_at - pr.merged_at)) / 3600.0\n  )::numeric, 1) AS \"Lead Time (hours)\"\nFROM deployments d\nJOIN deployment_pull_requests dpr ON dpr.deployment_id = d.deployment_id\nJOIN pull_requests pr ON pr.number = dpr.pr_number\nJOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE d.environment = '$environment'\n  AND ds.state = 'success'\n  AND pr.merged_at IS NOT NULL\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\n```"
           }
         }
       ],
@@ -216,7 +216,8 @@
         "w": 24,
         "x": 0,
         "y": 25
-      }
+      },
+      "description": "Learning guide section for Change Lead Time: Copilot vs Non-Copilot."
     },
     {
       "id": 300,
@@ -232,7 +233,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 3,
@@ -294,7 +296,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/pulls/pulls)\n\n`GET /repos/{owner}/{repo}/pulls` + `GET /orgs/{org}/copilot/seats`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`pull_requests`, `copilot_seats`\n\n### \ud83d\udcd0 How It's Calculated\n\nBar chart comparing median PR cycle time (merged_at - created_at) for Copilot vs non-Copilot PR authors.\n### \u26a0\ufe0f Calculation Challenges\n\n- **Calendar time** \u2014 wall-clock time including nights, weekends, and draft periods.\n- **Cohort balance not shown** \u2014 the chart doesn't show N (number of PRs) per bar. If cohorts have very different PR counts, the comparison is unreliable.\n- **Seat roster timing** \u2014 cohort uses current seat list. A developer who had a seat during the time range but lost it since then is now attributed to 'Non-Copilot'.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Statistical significance of the cycle time difference.\n- Effect size \u2014 is a 2-hour difference meaningful?\n\n### \ud83d\udd0d SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0\n  )::numeric, 1) AS \"PR Cycle Time (hours)\"\nFROM pull_requests pr\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/pulls/pulls)\n\n`GET /repos/{owner}/{repo}/pulls` + `GET /orgs/{org}/copilot/seats`\n\n### 🗄️ Database Table(s)\n\n`pull_requests`, `copilot_seats`\n\n### 📐 How It's Calculated\n\nBar chart comparing median PR cycle time (merged_at - created_at) for Copilot vs non-Copilot PR authors.\n### ⚠️ Calculation Challenges\n\n- **Calendar time** — wall-clock time including nights, weekends, and draft periods.\n- **Cohort balance not shown** — the chart doesn't show N (number of PRs) per bar. If cohorts have very different PR counts, the comparison is unreliable.\n- **Seat roster timing** — cohort uses current seat list. A developer who had a seat during the time range but lost it since then is now attributed to 'Non-Copilot'.\n### 💡 What This Metric Doesn't Tell You\n\n- Statistical significance of the cycle time difference.\n- Effect size — is a 2-hour difference meaningful?\n\n### 🔍 SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0\n  )::numeric, 1) AS \"PR Cycle Time (hours)\"\nFROM pull_requests pr\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\n```"
           }
         }
       ],
@@ -303,7 +305,8 @@
         "w": 24,
         "x": 0,
         "y": 36
-      }
+      },
+      "description": "Learning guide section for PR Cycle Time: Copilot vs Non-Copilot."
     },
     {
       "id": 301,
@@ -319,7 +322,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 4,
@@ -385,7 +389,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/pulls/pulls)\n\n`GET /repos/{owner}/{repo}/pulls?state=closed` + `GET /orgs/{org}/copilot/seats`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`pull_requests`, `copilot_seats`\n\n### \ud83d\udcd0 How It's Calculated\n\nWeekly time series of merged PR counts split by Copilot/non-Copilot PR author cohort.\n### \u26a0\ufe0f Calculation Challenges\n\n- **Roster timing mismatch** \u2014 today's seat list is used to attribute past PRs. A developer who got a Copilot seat last month is retroactively counted as 'Copilot Active' for all their historical PRs.\n- **No per-developer normalization** \u2014 if the Copilot cohort has 10 people and non-Copilot has 50, raw PR counts are misleading. Consider normalizing by cohort size.\n- **Mutually exclusive split** \u2014 the CTE creates a hard binary split; developers are never in both cohorts simultaneously.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Per-developer PR rate (normalize by cohort headcount for fair comparison).\n- PR complexity or size differences between cohorts.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  date_trunc('week', pr.merged_at) AS time,\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  COUNT(*) AS \"PRs\"\nFROM pull_requests pr\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/pulls/pulls)\n\n`GET /repos/{owner}/{repo}/pulls?state=closed` + `GET /orgs/{org}/copilot/seats`\n\n### 🗄️ Database Table(s)\n\n`pull_requests`, `copilot_seats`\n\n### 📐 How It's Calculated\n\nWeekly time series of merged PR counts split by Copilot/non-Copilot PR author cohort.\n### ⚠️ Calculation Challenges\n\n- **Roster timing mismatch** — today's seat list is used to attribute past PRs. A developer who got a Copilot seat last month is retroactively counted as 'Copilot Active' for all their historical PRs.\n- **No per-developer normalization** — if the Copilot cohort has 10 people and non-Copilot has 50, raw PR counts are misleading. Consider normalizing by cohort size.\n- **Mutually exclusive split** — the CTE creates a hard binary split; developers are never in both cohorts simultaneously.\n### 💡 What This Metric Doesn't Tell You\n\n- Per-developer PR rate (normalize by cohort headcount for fair comparison).\n- PR complexity or size differences between cohorts.\n\n### 🔍 SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  date_trunc('week', pr.merged_at) AS time,\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  COUNT(*) AS \"PRs\"\nFROM pull_requests pr\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1\n```"
           }
         }
       ],
@@ -394,7 +398,8 @@
         "w": 24,
         "x": 0,
         "y": 47
-      }
+      },
+      "description": "Learning guide section for Merged PRs by Cohort (weekly)."
     },
     {
       "id": 302,
@@ -410,7 +415,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 5,
@@ -476,7 +482,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/pulls/pulls)\n\n`GET /repos/{owner}/{repo}/pulls` + `GET /orgs/{org}/copilot/seats`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`pull_requests`, `copilot_seats`\n\n### \ud83d\udcd0 How It's Calculated\n\nWeekly sum of (pr.additions + pr.deletions) for each cohort. A rename counts as additions + deletions (double-counting).\n### \u26a0\ufe0f Calculation Challenges\n\n- **additions + deletions double-counts** \u2014 a 10-line rename (10 deletions + 10 additions) shows as 20 lines changed, inflating 'refactor-heavy' cohorts.\n- **Auto-generated files** \u2014 PRs containing lockfile regenerations or generated clients have very high line counts with minimal developer effort.\n- **Same roster timing caveat** \u2014 current seat list, not historical roster at merge time.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Code complexity or meaningful change volume.\n- Whether large line counts represent valuable engineering work.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  date_trunc('week', pr.merged_at) AS time,\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  SUM(COALESCE(pr.additions, 0) + COALESCE(pr.deletions, 0)) AS \"Lines Changed\"\nFROM pull_requests pr\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/pulls/pulls)\n\n`GET /repos/{owner}/{repo}/pulls` + `GET /orgs/{org}/copilot/seats`\n\n### 🗄️ Database Table(s)\n\n`pull_requests`, `copilot_seats`\n\n### 📐 How It's Calculated\n\nWeekly sum of (pr.additions + pr.deletions) for each cohort. A rename counts as additions + deletions (double-counting).\n### ⚠️ Calculation Challenges\n\n- **additions + deletions double-counts** — a 10-line rename (10 deletions + 10 additions) shows as 20 lines changed, inflating 'refactor-heavy' cohorts.\n- **Auto-generated files** — PRs containing lockfile regenerations or generated clients have very high line counts with minimal developer effort.\n- **Same roster timing caveat** — current seat list, not historical roster at merge time.\n### 💡 What This Metric Doesn't Tell You\n\n- Code complexity or meaningful change volume.\n- Whether large line counts represent valuable engineering work.\n\n### 🔍 SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n)\nSELECT\n  date_trunc('week', pr.merged_at) AS time,\n  CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS \"Cohort\",\n  SUM(COALESCE(pr.additions, 0) + COALESCE(pr.deletions, 0)) AS \"Lines Changed\"\nFROM pull_requests pr\nLEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\nWHERE pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1\n```"
           }
         }
       ],
@@ -485,7 +491,8 @@
         "w": 24,
         "x": 0,
         "y": 58
-      }
+      },
+      "description": "Learning guide section for Lines Changed by Cohort (weekly)."
     },
     {
       "id": 303,
@@ -501,7 +508,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 6,
@@ -563,7 +571,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\nGitHub Issues (incident label) + GitHub Deployments API + Copilot seats\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `issues`, `copilot_seats`\n\n### \ud83d\udcd0 How It's Calculated\n\nCompares change failure rate (incident co-occurrence / deployments) between deployers with and without active Copilot seats.\n### \u26a0\ufe0f Calculation Challenges\n\n- **Deployer cohort, not author cohort** \u2014 cohort uses creator_login (who triggered the deployment API call), not the developer who wrote the code.\n- **Incident sparsity** \u2014 with few incidents, 1 extra incident can swing a cohort's CFR by 10\u201320 percentage points.\n- **No statistical testing** \u2014 raw percentages with no confidence intervals. A 5% difference may be entirely due to chance with small N.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Statistical significance of the difference.\n- Causality \u2014 Copilot users and non-users may differ in many confounding ways.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n),\ndeploy_cohorts AS (\n  SELECT\n    d.deployment_id,\n    CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS cohort\n  FROM deployments d\n  JOIN deployment_pull_requests dpr ON dpr.deployment_id = d.deployment_id\n  JOIN pull_requests pr ON pr.number = dpr.pr_number\n  JOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\n  LEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\n  WHERE ds.state = 'success'\n  AND d.environment = '$environment'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n),\nfailures AS (\n  SELECT DISTINCT d.deployment_id\n  FROM deployments d\n  JOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\n  JOIN issues i ON i.labels::jsonb @> '[{\"name\":\"incident\"}]'\n    AND i.created_at BETWEEN d.created_at AND d.created_at + INTERVAL '24 hours'\n  WHERE ds.state = 'success'\n  AND d.environment = '$environment'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  dc.cohort AS \"Cohort\",\n  ROUND(COUNT(DISTINCT f.deployment_id)::numeric / NULLIF(COUNT(DISTINCT dc.deployment_id), 0) * 100, 1) AS \"CFR (%)\"\nFROM deploy_cohorts dc\nLEFT JOIN failures f ON f.deployment_id = dc.deployment_id\nGROUP BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\nGitHub Issues (incident label) + GitHub Deployments API + Copilot seats\n\n### 🗄️ Database Table(s)\n\n`deployments`, `issues`, `copilot_seats`\n\n### 📐 How It's Calculated\n\nCompares change failure rate (incident co-occurrence / deployments) between deployers with and without active Copilot seats.\n### ⚠️ Calculation Challenges\n\n- **Deployer cohort, not author cohort** — cohort uses creator_login (who triggered the deployment API call), not the developer who wrote the code.\n- **Incident sparsity** — with few incidents, 1 extra incident can swing a cohort's CFR by 10–20 percentage points.\n- **No statistical testing** — raw percentages with no confidence intervals. A 5% difference may be entirely due to chance with small N.\n### 💡 What This Metric Doesn't Tell You\n\n- Statistical significance of the difference.\n- Causality — Copilot users and non-users may differ in many confounding ways.\n\n### 🔍 SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n),\ndeploy_cohorts AS (\n  SELECT\n    d.deployment_id,\n    CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS cohort\n  FROM deployments d\n  JOIN deployment_pull_requests dpr ON dpr.deployment_id = d.deployment_id\n  JOIN pull_requests pr ON pr.number = dpr.pr_number\n  JOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\n  LEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\n  WHERE ds.state = 'success'\n  AND d.environment = '$environment'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n),\nfailures AS (\n  SELECT DISTINCT d.deployment_id\n  FROM deployments d\n  JOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\n  JOIN issues i ON i.labels::jsonb @> '[{\"name\":\"incident\"}]'\n    AND i.created_at BETWEEN d.created_at AND d.created_at + INTERVAL '24 hours'\n  WHERE ds.state = 'success'\n  AND d.environment = '$environment'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  dc.cohort AS \"Cohort\",\n  ROUND(COUNT(DISTINCT f.deployment_id)::numeric / NULLIF(COUNT(DISTINCT dc.deployment_id), 0) * 100, 1) AS \"CFR (%)\"\nFROM deploy_cohorts dc\nLEFT JOIN failures f ON f.deployment_id = dc.deployment_id\nGROUP BY 1\n```"
           }
         }
       ],
@@ -572,7 +580,8 @@
         "w": 24,
         "x": 0,
         "y": 69
-      }
+      },
+      "description": "Learning guide section for Change Fail Rate: Copilot vs Non-Copilot."
     },
     {
       "id": 304,
@@ -588,7 +597,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 7,
@@ -650,7 +660,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `GET /orgs/{org}/copilot/seats`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`deployments`, `deployment_statuses`, `deployment_pull_requests`, `pull_requests`, `copilot_seats`\n\n### \ud83d\udcd0 How It's Calculated\n\nCompares median deploy-gap MTTR (proxy) between deployments linked to PRs whose authors do and do not have active Copilot seats. Cohort assignment comes from the linked PR author (`pr.user_id`), not `d.creator_login`.\n### \u26a0\ufe0f Calculation Challenges\n\n- **Same proxy limitation** \u2014 deploy-gap, not actual service restoration time.\n- **Very sparse data per cohort** \u2014 splitting an already-sparse failure dataset by two cohorts means each bar may represent only 1\u20132 recovery events. Median of N=1 = that single value.\n- **PR-link dependence** \u2014 cohort assignment only works for deployments that can be linked back to a PR; unlinked deployments cannot be attributed to an author cohort.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Whether Copilot helps teams recover faster or if recovery is driven by other factors.\n- The number of failures in each cohort (denominator not shown).\n\n### \ud83d\udd0d SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n),\nfailure_deploys AS (\n  SELECT\n    d.deployment_id,\n    d.environment,\n    d.created_at AS failed_at,\n    CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS cohort,\n    LEAD(d.created_at) OVER (PARTITION BY d.environment ORDER BY d.created_at) AS recovered_at\n  FROM deployments d\n  JOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\n  LEFT JOIN deployment_pull_requests dpr ON dpr.deployment_id = d.deployment_id\n  LEFT JOIN pull_requests pr ON pr.number = dpr.pr_number\n  LEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\n  WHERE ds.state = 'failure'\n  AND d.environment = '$environment'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  cohort AS \"Cohort\",\n  ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (recovered_at - failed_at)) / 3600.0\n  )::numeric, 1) AS \"Median MTTR (hours)\"\nFROM failure_deploys\nWHERE recovered_at IS NOT NULL\nGROUP BY 1\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/deployments/deployments)\n\n`GET /repos/{owner}/{repo}/deployments` + `GET /orgs/{org}/copilot/seats`\n\n### 🗄️ Database Table(s)\n\n`deployments`, `deployment_statuses`, `deployment_pull_requests`, `pull_requests`, `copilot_seats`\n\n### 📐 How It's Calculated\n\nCompares median deploy-gap MTTR (proxy) between deployments linked to PRs whose authors do and do not have active Copilot seats. Cohort assignment comes from the linked PR author (`pr.user_id`), not `d.creator_login`.\n### ⚠️ Calculation Challenges\n\n- **Same proxy limitation** — deploy-gap, not actual service restoration time.\n- **Very sparse data per cohort** — splitting an already-sparse failure dataset by two cohorts means each bar may represent only 1–2 recovery events. Median of N=1 = that single value.\n- **PR-link dependence** — cohort assignment only works for deployments that can be linked back to a PR; unlinked deployments cannot be attributed to an author cohort.\n### 💡 What This Metric Doesn't Tell You\n\n- Whether Copilot helps teams recover faster or if recovery is driven by other factors.\n- The number of failures in each cohort (denominator not shown).\n\n### 🔍 SQL Query\n\n```sql\nWITH copilot_users AS (\n  SELECT assignee_id FROM copilot_seats WHERE last_activity_at >= NOW() - INTERVAL '28 days'\n),\nfailure_deploys AS (\n  SELECT\n    d.deployment_id,\n    d.environment,\n    d.created_at AS failed_at,\n    CASE WHEN cu.assignee_id IS NOT NULL THEN 'Copilot Active' ELSE 'Non-Copilot' END AS cohort,\n    LEAD(d.created_at) OVER (PARTITION BY d.environment ORDER BY d.created_at) AS recovered_at\n  FROM deployments d\n  JOIN deployment_statuses ds ON ds.deployment_id = d.deployment_id\n  LEFT JOIN deployment_pull_requests dpr ON dpr.deployment_id = d.deployment_id\n  LEFT JOIN pull_requests pr ON pr.number = dpr.pr_number\n  LEFT JOIN copilot_users cu ON pr.user_id = cu.assignee_id\n  WHERE ds.state = 'failure'\n  AND d.environment = '$environment'\n  AND d.created_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  cohort AS \"Cohort\",\n  ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (recovered_at - failed_at)) / 3600.0\n  )::numeric, 1) AS \"Median MTTR (hours)\"\nFROM failure_deploys\nWHERE recovered_at IS NOT NULL\nGROUP BY 1\n```"
           }
         }
       ],
@@ -659,7 +669,8 @@
         "w": 24,
         "x": 0,
         "y": 80
-      }
+      },
+      "description": "Learning guide section for MTTR: Copilot vs Non-Copilot."
     },
     {
       "id": 305,
@@ -675,7 +686,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 9,
@@ -757,7 +769,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source [\u2192 docs](https://docs.github.com/en/rest/copilot/copilot-user-management)\n\n`GET /orgs/{org}/copilot/seats`\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`copilot_seats`\n\n### \ud83d\udcd0 How It's Calculated\n\nRow count of copilot_seats table. Used as a data health indicator alongside 'Last Successful Sync'.\n### \u26a0\ufe0f Calculation Challenges\n\n- **Silent 403 failure** \u2014 if the sync server receives a 403 on the seats endpoint, it logs a warning and continues. The table stays at 0 rows. A 'successful' sync job \u2260 seats data was loaded.\n- **TRUNCATE + INSERT every sync** \u2014 unlike PRs and deployments (incremental), copilot_seats is fully replaced on every sync. A 403 leaves it empty.\n- **Proxy for sync health** \u2014 use this alongside 'Last Successful Sync' to confirm data freshness; check server logs if this shows 0.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Whether seat data is accurate or stale.\n- Breakdown by team or repository.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nSELECT COUNT(*) AS \"Copilot Seats\" FROM copilot_seats\n```"
+            "content": "### 📡 GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-user-management)\n\n`GET /orgs/{org}/copilot/seats`\n\n### 🗄️ Database Table(s)\n\n`copilot_seats`\n\n### 📐 How It's Calculated\n\nRow count of copilot_seats table. Used as a data health indicator alongside 'Last Successful Sync'.\n### ⚠️ Calculation Challenges\n\n- **Silent 403 failure** — if the sync server receives a 403 on the seats endpoint, it logs a warning and continues. The table stays at 0 rows. A 'successful' sync job ≠ seats data was loaded.\n- **TRUNCATE + INSERT every sync** — unlike PRs and deployments (incremental), copilot_seats is fully replaced on every sync. A 403 leaves it empty.\n- **Proxy for sync health** — use this alongside 'Last Successful Sync' to confirm data freshness; check server logs if this shows 0.\n### 💡 What This Metric Doesn't Tell You\n\n- Whether seat data is accurate or stale.\n- Breakdown by team or repository.\n\n### 🔍 SQL Query\n\n```sql\nSELECT COUNT(*) AS \"Copilot Seats\" FROM copilot_seats\n```"
           }
         }
       ],
@@ -766,7 +778,8 @@
         "w": 24,
         "x": 0,
         "y": 87
-      }
+      },
+      "description": "Learning guide section for Copilot Seats Loaded."
     },
     {
       "id": 306,
@@ -782,7 +795,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     },
     {
       "id": 10,
@@ -860,7 +874,7 @@
           },
           "options": {
             "mode": "markdown",
-            "content": "### \ud83d\udce1 GitHub API Source\n\nInternal sync_jobs table (no GitHub API call)\n\n### \ud83d\uddc4\ufe0f Database Table(s)\n\n`sync_jobs`\n\n### \ud83d\udcd0 How It's Calculated\n\nMAX(finished_at) from sync_jobs where status='success'. Shows when the last complete sync run finished.\n### \u26a0\ufe0f Calculation Challenges\n\n- **'Successful' sync \u2260 all data loaded** \u2014 a sync job completes with status='success' while individual fetchers (e.g., copilot seats) fail silently. Always check records_synced per resource.\n- **Timestamps in UTC** \u2014 finished_at is stored in UTC. Grafana displays in browser timezone; a sync at 00:00 UTC appears as yesterday in UTC-5 timezones.\n- **sync_jobs is append-only** \u2014 each sync adds a row and the table grows indefinitely. No automatic pruning.\n### \ud83d\udca1 What This Metric Doesn't Tell You\n\n- Whether all resources were successfully fetched (check records_synced column in the job record).\n- Failure reason if the last job has status other than 'success'.\n\n### \ud83d\udd0d SQL Query\n\n```sql\nSELECT MAX(finished_at) AS \"Last Successful Sync\" FROM sync_jobs WHERE status = 'success'\n```"
+            "content": "### 📡 GitHub API Source\n\nInternal sync_jobs table (no GitHub API call)\n\n### 🗄️ Database Table(s)\n\n`sync_jobs`\n\n### 📐 How It's Calculated\n\nMAX(finished_at) from sync_jobs where status='success'. Shows when the last complete sync run finished.\n### ⚠️ Calculation Challenges\n\n- **'Successful' sync ≠ all data loaded** — a sync job completes with status='success' while individual fetchers (e.g., copilot seats) fail silently. Always check records_synced per resource.\n- **Timestamps in UTC** — finished_at is stored in UTC. Grafana displays in browser timezone; a sync at 00:00 UTC appears as yesterday in UTC-5 timezones.\n- **sync_jobs is append-only** — each sync adds a row and the table grows indefinitely. No automatic pruning.\n### 💡 What This Metric Doesn't Tell You\n\n- Whether all resources were successfully fetched (check records_synced column in the job record).\n- Failure reason if the last job has status other than 'success'.\n\n### 🔍 SQL Query\n\n```sql\nSELECT MAX(finished_at) AS \"Last Successful Sync\" FROM sync_jobs WHERE status = 'success'\n```"
           }
         }
       ],
@@ -869,7 +883,8 @@
         "w": 24,
         "x": 0,
         "y": 94
-      }
+      },
+      "description": "Learning guide section for Last Successful Sync."
     },
     {
       "id": 307,
@@ -885,7 +900,8 @@
       "options": {
         "mode": "markdown",
         "content": "---"
-      }
+      },
+      "description": "Section divider."
     }
   ],
   "tags": [

--- a/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
+++ b/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
@@ -43,7 +43,7 @@
       "id": 8,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner \u2014 shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "description": "Data mode banner \u2014 shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -61,7 +61,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'live' THEN '\ud83d\udce1 Live Data \u2014 ' || COALESCE(source_label, '')\n    WHEN 'seed' THEN '\ud83c\udf31 Synthetic Seed Data \u2014 ' || COALESCE(source_label, '')\n    WHEN 'demo' THEN '\ud83c\udfae Demo Environment \u2014 ' || COALESCE(source_label, '')\n    ELSE '\u2753 Unknown Mode'\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '\ud83c\udf31 Synthetic Seed Data'\n    ELSE '\ud83d\udce1 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
           "format": "table"
         }
       ],
@@ -88,16 +88,6 @@
                 }
               }
             },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "Demo Environment",
-                "result": {
-                  "color": "#5794F2",
-                  "index": 2
-                }
-              }
-            }
           ],
           "thresholds": {
             "mode": "absolute",

--- a/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
+++ b/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
@@ -61,7 +61,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"\nFROM (SELECT 1) dummy",
           "format": "table"
         }
       ],
@@ -71,7 +71,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Live Data",
+                "pattern": ".*Live Data.*",
                 "result": {
                   "color": "#73BF69",
                   "index": 0
@@ -81,7 +81,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Seed Data",
+                "pattern": ".*Seed Data.*",
                 "result": {
                   "color": "#FF9830",
                   "index": 1
@@ -91,7 +91,7 @@
             {
               "type": "regex",
               "options": {
-                "pattern": "Demo Environment",
+                "pattern": ".*Demo Environment.*",
                 "result": {
                   "color": "#5794F2",
                   "index": 2
@@ -119,7 +119,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/.*/",
           "values": false
         },
         "colorMode": "background_solid",

--- a/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
+++ b/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
@@ -87,7 +87,7 @@
                   "index": 1
                 }
               }
-            },
+            }
           ],
           "thresholds": {
             "mode": "absolute",

--- a/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
+++ b/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
@@ -61,7 +61,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')\n      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'live' THEN '📡 Live Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      WHEN 'demo' THEN '🎮 Demo Environment' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '❓ Unknown Mode'\n    END\n  FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚙️ Awaiting first sync…'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/scripts/seed.ts
+++ b/v2/scripts/seed.ts
@@ -184,7 +184,7 @@ async function main() {
   await pool.query('TRUNCATE TABLE data_mode');
   await pool.query(
     `INSERT INTO data_mode (mode, source_label, source_url) VALUES ($1, $2, $3)`,
-    ['seed', 'Synthetic seed data', null]
+    ['seeded', 'Synthetic seed data', null]
   );
 
   // Run bridge resolver inline (only link PRs merged before the deployment was created)

--- a/v2/scripts/seed.ts
+++ b/v2/scripts/seed.ts
@@ -184,7 +184,7 @@ async function main() {
   await pool.query('TRUNCATE TABLE data_mode');
   await pool.query(
     `INSERT INTO data_mode (mode, source_label, source_url) VALUES ($1, $2, $3)`,
-    ['seed', 'Synthetic seed data', null]
+    ['seed', 'Not connected to GitHub', null]
   );
 
   // Run bridge resolver inline (only link PRs merged before the deployment was created)

--- a/v2/src/config.ts
+++ b/v2/src/config.ts
@@ -21,7 +21,7 @@ export const config = {
     password: requireEnv('PG_PASSWORD'),
   },
   port: parseInt(process.env.PORT ?? '3001', 10),
-  dataMode: (process.env.DATA_MODE ?? 'live') as 'live' | 'seed' | 'demo',
+  dataMode: (process.env.DATA_MODE ?? 'live') as 'live' | 'seeded',
   dataSourceLabel: process.env.DATA_SOURCE_LABEL ?? '',
   dataSourceUrl: process.env.DATA_SOURCE_URL ?? null,
 };

--- a/v2/src/config.ts
+++ b/v2/src/config.ts
@@ -22,6 +22,7 @@ export const config = {
   },
   port: parseInt(process.env.PORT ?? '3001', 10),
   dataMode: (process.env.DATA_MODE ?? 'live') as 'live' | 'seed' | 'demo',
-  dataSourceLabel: process.env.DATA_SOURCE_LABEL ?? '',
+  dataSourceLabel: process.env.DATA_SOURCE_LABEL ||
+    `${process.env.GITHUB_ORG ?? ''}/${process.env.GITHUB_REPO ?? ''}`,
   dataSourceUrl: process.env.DATA_SOURCE_URL ?? null,
 };

--- a/v2/src/config.ts
+++ b/v2/src/config.ts
@@ -22,7 +22,10 @@ export const config = {
   },
   port: parseInt(process.env.PORT ?? '3001', 10),
   dataMode: (process.env.DATA_MODE ?? 'live') as 'live' | 'seed' | 'demo',
-  dataSourceLabel: process.env.DATA_SOURCE_LABEL ||
-    `${process.env.GITHUB_ORG ?? ''}/${process.env.GITHUB_REPO ?? ''}`,
+  dataSourceLabel:
+    process.env.DATA_SOURCE_LABEL ||
+    (process.env.GITHUB_ORG && process.env.GITHUB_REPO
+      ? `${process.env.GITHUB_ORG}/${process.env.GITHUB_REPO}`
+      : ''),
   dataSourceUrl: process.env.DATA_SOURCE_URL ?? null,
 };

--- a/v2/src/sync/orchestrator.ts
+++ b/v2/src/sync/orchestrator.ts
@@ -40,10 +40,11 @@ async function doSync(pool: Pool, octokit: Octokit, jobId: number): Promise<void
   const recordCounts: Record<string, number> = {};
 
   // ── 1. Set data_mode banner ──────────────────────────────────────────────
+  const sourceLabel = config.dataSourceLabel || `${org}/${repo}`;
   await pool.query('DELETE FROM data_mode');
   await pool.query(
     `INSERT INTO data_mode (mode, source_label, source_url) VALUES ($1, $2, $3)`,
-    [config.dataMode, config.dataSourceLabel, config.dataSourceUrl ?? null]
+    [config.dataMode, sourceLabel, config.dataSourceUrl ?? null]
   );
 
   // ── 2. Copilot Seats (TRUNCATE + INSERT) ─────────────────────────────────

--- a/v2/tests/config.test.ts
+++ b/v2/tests/config.test.ts
@@ -62,11 +62,11 @@ describe('config', () => {
     expect(config.dataMode).toBe('live');
   });
 
-  it('DATA_MODE can be set to "seed"', async () => {
+  it('DATA_MODE can be set to "seeded"', async () => {
     setRequiredEnv();
-    process.env.DATA_MODE = 'seed';
+    process.env.DATA_MODE = 'seeded';
     const { config } = await import('../src/config');
-    expect(config.dataMode).toBe('seed');
+    expect(config.dataMode).toBe('seeded');
   });
 
   it('DATA_SOURCE_LABEL is read from env', async () => {

--- a/v2/tests/dashboards.test.ts
+++ b/v2/tests/dashboards.test.ts
@@ -13,10 +13,18 @@ const ALL_DASHBOARDS = [
   '05-copilot-adoption.json',
   '06-copilot-code-impact.json',
   '07-dora-vs-copilot.json',
+  '08-overview-edu.json',
+  '09-deployment-frequency-edu.json',
+  '10-lead-time-edu.json',
+  '11-change-failure-rate-edu.json',
+  '12-mean-time-to-recovery-edu.json',
+  '13-copilot-adoption-edu.json',
+  '14-copilot-code-impact-edu.json',
+  '15-dora-vs-copilot-edu.json',
 ];
 
 const DORA_PILLAR_DASHBOARDS = ALL_DASHBOARDS.slice(1, 5);
-const COPILOT_DASHBOARDS = ALL_DASHBOARDS.slice(5);
+const COPILOT_DASHBOARDS = ALL_DASHBOARDS.slice(5, 8);
 
 function loadDashboard(filename: string): any {
   const content = readFileSync(join(dashboardDir, filename), 'utf-8');
@@ -24,7 +32,7 @@ function loadDashboard(filename: string): any {
 }
 
 describe('dashboard files exist', () => {
-  it('all 8 dashboard files are present', () => {
+  it('all 16 dashboard files are present', () => {
     const existing = readdirSync(dashboardDir);
     for (const filename of ALL_DASHBOARDS) {
       expect(existing).toContain(filename);
@@ -119,7 +127,7 @@ describe('Copilot dashboards', () => {
 });
 
 describe('cross-dashboard uniqueness', () => {
-  it('all UIDs are unique across all 8 dashboards', () => {
+  it('all UIDs are unique across all 16 dashboards', () => {
     const uids = ALL_DASHBOARDS.map(f => loadDashboard(f).uid);
     const unique = new Set(uids);
     expect(unique.size).toBe(uids.length);


### PR DESCRIPTION
## Problem

All 16 dashboards display a data mode banner (first stat panel) that queries the `data_mode` table. Currently the banner is **always empty and red** because:

1. **Empty table → red**: `FROM data_mode LIMIT 1` returns 0 rows when the table hasn't been populated (before any sync or seed has run). Grafana falls back to the `dark-red` default threshold.
2. **Incomplete text**: `DATA_SOURCE_LABEL` env var defaults to `''` (empty string), causing banner text like `'📡 Live Data — '` with a trailing dash and nothing after.
3. **Wrong color**: Seed mode uses orange (`#FA6400`) — should be amber (`#FF9830`).

## Changes Required

### 1. All 16 dashboard JSON files (`v2/grafana/dashboards/00-overview.json` through `15-dora-vs-copilot-edu.json`)

Update the `rawSql` in the first panel (banner stat panel) to use a scalar subquery with `COALESCE` so Grafana always receives exactly 1 row:

```sql
SELECT COALESCE(
  (SELECT
    CASE mode
      WHEN 'live' THEN '📡 Live Data — ' || NULLIF(source_label, '')
      WHEN 'seed' THEN '🌱 Synthetic Seed Data — ' || NULLIF(source_label, '')
      WHEN 'demo' THEN '🎮 Demo Environment — ' || NULLIF(source_label, '')
      ELSE '❓ Unknown Mode'
    END
  FROM data_mode ORDER BY updated_at DESC LIMIT 1),
  '⚙️ Awaiting first sync…'
) AS "Data Source"
```

Note: `NULLIF(source_label, '')` removes the trailing `' — '` when the label is empty (returns NULL which `||` short-circuits in PostgreSQL).

Also change the **Seed Data regex mapping color** from `#FA6400` (orange) to `#FF9830` (amber):

```json
{
  "type": "regex",
  "options": {
    "pattern": "Seed Data",
    "result": {
      "color": "#FF9830",
      "index": 1
    }
  }
}
```

### 2. `v2/src/config.ts`

Default `dataSourceLabel` to the org/repo when `DATA_SOURCE_LABEL` is not set:

```ts
dataSourceLabel: process.env.DATA_SOURCE_LABEL ||
  `${process.env.GITHUB_ORG ?? ''}/${process.env.GITHUB_REPO ?? ''}`,
```

This ensures the banner shows something meaningful (e.g. `nicolehaugen/CustomMetricsDashboard`) even when the env var is not configured.

### 3. `v2/scripts/seed.ts`

Change the seed `source_label` from `'Synthetic seed data'` (redundant with the mode text) to `'Not connected to GitHub'`:

```ts
['seed', 'Not connected to GitHub', null]
```

Result: banner shows `🌱 Synthetic Seed Data — Not connected to GitHub`

### 4. `v2/tests/dashboards.test.ts`

Extend `ALL_DASHBOARDS` to cover all 16 files (currently only 00–07 are tested):

```ts
const ALL_DASHBOARDS = [
  '00-overview.json',
  '01-deployment-frequency.json',
  '02-lead-time.json',
  '03-change-failure-rate.json',
  '04-mean-time-to-recovery.json',
  '05-copilot-adoption.json',
  '06-copilot-code-impact.json',
  '07-dora-vs-copilot.json',
  '08-overview-edu.json',
  '09-deployment-frequency-edu.json',
  '10-lead-time-edu.json',
  '11-change-failure-rate-edu.json',
  '12-mean-time-to-recovery-edu.json',
  '13-copilot-adoption-edu.json',
  '14-copilot-code-impact-edu.json',
  '15-dora-vs-copilot-edu.json',
];
```

Also update the `'all 8 dashboard files are present'` test title/count to `'all 16 dashboard files are present'`.

## Expected Outcomes

| Condition | Banner shows |
|-----------|-------------|
| Table empty (no sync run yet) | `⚙️ Awaiting first sync…` (red — intentional, signals setup needed) |
| Seeded | `🌱 Synthetic Seed Data — Not connected to GitHub` (amber) |
| Live sync, label set | `📡 Live Data — nicolehaugen/CustomMetricsDashboard` (green) |
| Live sync, label not set | `📡 Live Data` (green, no trailing dash) |

## Validation

Run from `v2/`:
```
npm test && npm run lint && npm run build
```

All three must pass before merging.
