### PR TITLE
fix: dashboard banner always shows data source — COALESCE fallback + startup init

### DIFF
--- a/v2/.env.example
+++ b/v2/.env.example
@@ -15,6 +15,6 @@ PG_PASSWORD=postgres
 PORT=3001
 
 # Data Mode Banner
-DATA_MODE=live               # live | seed | demo
+DATA_MODE=live               # live | seed
 DATA_SOURCE_LABEL=your-org/your-repo
 DATA_SOURCE_URL=https://github.com/your-org/your-repo

--- a/v2/README.md
+++ b/v2/README.md
@@ -10,6 +10,217 @@ GitHub data → PostgreSQL → Grafana. Measures the four DORA pillars plus Copi
 GitHub API → sync service → data/raw/ → PostgreSQL → Grafana dashboards
 ```
 
+## Data Sources
+
+This dashboard pulls from two distinct GitHub data sources that behave very differently from each other.
+
+### DORA Data
+
+DORA metrics are derived from four GitHub REST API endpoint groups:
+
+| Data | GitHub API | Used for |
+|------|-----------|---------|
+| Pull requests | `GET /repos/{owner}/{repo}/pulls` | Lead Time, Deployment Frequency, Cohort |
+| Deployments + statuses | `GET /repos/{owner}/{repo}/deployments` | Deployment Frequency, MTTR, Lead Time |
+| Issues | `GET /repos/{owner}/{repo}/issues` | Change Failure Rate (`incident` label) |
+| Workflow runs | `GET /repos/{owner}/{repo}/actions/runs` | Lead Time (build time component) |
+
+**How the download works:**
+
+The sync service uses the [Octokit](https://github.com/octokit/rest.js) SDK. Each endpoint is paginated — GitHub returns up to 100 records per page with a `Link: next` header pointing to the next page. Octokit's `paginate()` follows these headers automatically until all pages are exhausted.
+
+```
+sync-server
+  └── octokit.paginate(pulls.list, { per_page: 100 })
+        ├── GET /repos/org/repo/pulls?page=1  → 100 PRs
+        ├── GET /repos/org/repo/pulls?page=2  → 100 PRs
+        └── GET /repos/org/repo/pulls?page=3  → 47 PRs  ← done
+```
+
+PRs require a **second API call per record** to fetch `additions`, `deletions`, and `changed_files` — these fields are not included in the list response, only in the individual `GET /pulls/{number}` detail endpoint.
+
+**Incremental syncing:**
+
+After the first full sync, subsequent syncs only fetch records updated since `last_synced_at` (stored in the `sync_state` table). New data is merged into the DB using `ON CONFLICT ... DO UPDATE` (UPSERT) — existing rows are updated, new rows are inserted, nothing is deleted.
+
+---
+
+### Copilot Data
+
+Copilot metrics come from three separate API surfaces:
+
+| Data | GitHub API | Used for |
+|------|-----------|---------|
+| Seats | `GET /orgs/{org}/copilot/billing/seats` | Who has a license, last activity |
+| Org metrics | `GET /orgs/{org}/copilot/metrics/reports/organization-28-day/latest` | Usage aggregates (DAU, LoC, acceptance rate) |
+| User metrics | `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` | Per-user breakdown |
+
+**How the download works — two hops:**
+
+The Copilot metrics API (version `2026-03-10`) does **not** return data inline. Instead it returns a signed download envelope:
+
+```
+Step 1 — Ask GitHub where the report is:
+  sync-server
+    └── octokit.request('GET /orgs/{org}/copilot/metrics/reports/...')
+          └── Response: {
+                "download_links": [
+                  "https://<storage-host>/.../report-part-1.ndjson?<signature-params>",
+                  "https://<storage-host>/.../report-part-2.ndjson?<signature-params>"
+                ]
+              }
+
+Step 2 — Download each file directly from cloud storage:
+  sync-server
+    └── fetch("https://<storage-host>/...?<signature-params>")
+          └── Response: NDJSON file (one JSON object per line)
+```
+
+**Step 1 in detail:** GitHub does not send the metrics data in the API response. Instead it returns a list of pre-signed cloud storage URLs — temporary, time-limited pointers to where the data files live. The signature query parameters embedded in each URL act as the credential; your GitHub token is not needed for step 2. The report may be split across multiple parts (multiple URLs in `download_links`), so the fetcher loops over all of them and concatenates the results. The signed URLs expire shortly after being issued, so they must be fetched promptly.
+
+The file is **NDJSON** (Newline-Delimited JSON) — not a JSON array. Each line is a separate JSON object parsed independently:
+
+```
+{"day":"2026-04-01","daily_active_users":42,...}
+{"day":"2026-04-02","daily_active_users":45,...}
+{"day":"2026-04-03","daily_active_users":38,...}
+```
+
+GitHub uses this pattern because 28 days × thousands of users is a large dataset — offloading the bulk transfer to S3 is more efficient than streaming it through GitHub's API servers.
+
+**Full replace, not incremental:**
+
+The Copilot API has no `since` parameter and no cursor. It always returns the current 28-day rolling window. Seats represent *current state* — if someone loses a seat, they simply disappear from the response (no deletion event). For both reasons, Copilot tables are always `TRUNCATE`d before re-inserting on every sync.
+
+**Failure behaviour:**
+
+If the Copilot API returns `403` or `404` (missing `admin:org` scope, Copilot not enabled for the org, etc.), the error is caught per-fetcher and logged as a warning. The sync continues and completes successfully for the DORA data. Check `docker logs v2-sync-server-1 | grep -E "WARN|copilot"` if Copilot panels show no data after a successful sync.
+
+---
+
+## Database Schema
+
+The database has three logical groups of tables.
+
+### DORA tables
+
+```mermaid
+erDiagram
+    pull_requests {
+        int number PK
+        text state
+        timestamptz merged_at
+        text user_login
+        bigint user_id
+        int additions
+        int deletions
+        jsonb labels
+    }
+    deployments {
+        bigint deployment_id PK
+        text sha
+        text ref
+        text environment
+        timestamptz created_at
+    }
+    deployment_statuses {
+        bigint deployment_id FK
+        text state
+        timestamptz created_at
+    }
+    deployment_pull_requests {
+        bigint deployment_id FK
+        int pr_number FK
+        text match_type
+    }
+    issues {
+        int number PK
+        text state
+        timestamptz created_at
+        timestamptz closed_at
+        jsonb labels
+    }
+    workflow_runs {
+        bigint run_id PK
+        text name
+        text status
+        text conclusion
+        timestamptz created_at
+        timestamptz run_started_at
+    }
+
+    deployments ||--o{ deployment_statuses : "has statuses"
+    deployments ||--o{ deployment_pull_requests : "contains PRs"
+    pull_requests ||--o{ deployment_pull_requests : "deployed via"
+```
+
+The `deployment_pull_requests` bridge table is populated by the **bridge resolver** — it links each deployment to the PRs it contains by matching `deployment.sha` to `pull_request.merge_commit_sha` (direct match) or `pull_request.head_sha` (squash fallback). This bridge is what makes Lead Time and the DORA × Copilot cohort analysis possible.
+
+### Copilot tables
+
+```mermaid
+erDiagram
+    copilot_seats {
+        bigint assignee_id PK
+        text assignee_login
+        timestamptz last_activity_at
+        text last_activity_editor
+        text plan_type
+    }
+    copilot_org_metrics {
+        date day PK
+        int daily_active_users
+        int monthly_active_users
+        int loc_suggested_to_add_sum
+        int loc_added_sum
+        jsonb totals_by_feature
+        jsonb totals_by_ide
+    }
+    copilot_user_metrics {
+        date day
+        text user_login
+        int loc_added_sum
+        boolean used_agent
+        boolean used_chat
+        jsonb totals_by_ide
+    }
+
+    copilot_seats ||--o{ copilot_user_metrics : "matched by login"
+```
+
+`copilot_seats` and `copilot_user_metrics` are joined by `user_login` in Grafana SQL — there is no FK constraint because the metrics data uses login strings while seats use `assignee_id`. Both tables are fully replaced on every sync.
+
+### Infrastructure tables
+
+```mermaid
+erDiagram
+    sync_jobs {
+        int id PK
+        text status
+        timestamptz started_at
+        timestamptz finished_at
+        jsonb records_synced
+        text error_message
+    }
+    sync_state {
+        text resource PK
+        timestamptz last_synced_at
+    }
+    data_mode {
+        int id PK
+        text mode
+        text source_label
+        text source_url
+        timestamptz updated_at
+    }
+```
+
+- **`sync_jobs`** — audit log of every sync run; powers `GET /api/sync/jobs`
+- **`sync_state`** — tracks `last_synced_at` per resource for incremental DORA fetches
+- **`data_mode`** — single-row config table read by every Grafana dashboard to render the data source banner
+
+---
+
 ## Requirements
 
 - Docker + Docker Compose
@@ -95,12 +306,11 @@ Every dashboard shows a banner indicating the data source:
 | Mode | Color | Label |
 |------|-------|-------|
 | `live` | 🟢 Green | 📡 Live Data — your-org/your-repo |
-| `seed` | 🟠 Amber | 🌱 Synthetic Seed Data |
-| `demo` | 🔵 Blue | 🎮 Demo Environment |
+| `seed` | 🟠 Amber | 🌱 Synthetic Seed Data — your-org/your-repo |
 
 Configure via `.env`:
 ```
-DATA_MODE=live
+DATA_MODE=live               # live | seed
 DATA_SOURCE_LABEL=my-org/my-repo
 DATA_SOURCE_URL=https://github.com/my-org/my-repo
 ```

--- a/v2/grafana/dashboards/00-overview.json
+++ b/v2/grafana/dashboards/00-overview.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/00-overview.json
+++ b/v2/grafana/dashboards/00-overview.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/01-deployment-frequency.json
+++ b/v2/grafana/dashboards/01-deployment-frequency.json
@@ -35,7 +35,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/01-deployment-frequency.json
+++ b/v2/grafana/dashboards/01-deployment-frequency.json
@@ -35,7 +35,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/02-lead-time.json
+++ b/v2/grafana/dashboards/02-lead-time.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/02-lead-time.json
+++ b/v2/grafana/dashboards/02-lead-time.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/03-change-failure-rate.json
+++ b/v2/grafana/dashboards/03-change-failure-rate.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/03-change-failure-rate.json
+++ b/v2/grafana/dashboards/03-change-failure-rate.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/04-mean-time-to-recovery.json
+++ b/v2/grafana/dashboards/04-mean-time-to-recovery.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/04-mean-time-to-recovery.json
+++ b/v2/grafana/dashboards/04-mean-time-to-recovery.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/05-copilot-adoption.json
+++ b/v2/grafana/dashboards/05-copilot-adoption.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/05-copilot-adoption.json
+++ b/v2/grafana/dashboards/05-copilot-adoption.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/06-copilot-code-impact.json
+++ b/v2/grafana/dashboards/06-copilot-code-impact.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/06-copilot-code-impact.json
+++ b/v2/grafana/dashboards/06-copilot-code-impact.json
@@ -42,7 +42,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/07-dora-vs-copilot.json
+++ b/v2/grafana/dashboards/07-dora-vs-copilot.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/07-dora-vs-copilot.json
+++ b/v2/grafana/dashboards/07-dora-vs-copilot.json
@@ -65,7 +65,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/08-overview-edu.json
+++ b/v2/grafana/dashboards/08-overview-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/08-overview-edu.json
+++ b/v2/grafana/dashboards/08-overview-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/09-deployment-frequency-edu.json
+++ b/v2/grafana/dashboards/09-deployment-frequency-edu.json
@@ -14,7 +14,7 @@
       "id": 9,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner \u2014 shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -32,7 +32,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '\ud83c\udf31 Synthetic Seed Data' || COALESCE(' \u2014 ' || NULLIF(source_label, ''), '')\n      ELSE '\ud83d\udce1 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '\u26a0\ufe0f No data loaded \u2014 run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/09-deployment-frequency-edu.json
+++ b/v2/grafana/dashboards/09-deployment-frequency-edu.json
@@ -32,7 +32,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '\ud83c\udf31 Synthetic Seed Data'\n    ELSE '\ud83d\udce1 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '\ud83c\udf31 Synthetic Seed Data' || COALESCE(' \u2014 ' || NULLIF(source_label, ''), '')\n      ELSE '\ud83d\udce1 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '\u26a0\ufe0f No data loaded \u2014 run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/10-lead-time-edu.json
+++ b/v2/grafana/dashboards/10-lead-time-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/10-lead-time-edu.json
+++ b/v2/grafana/dashboards/10-lead-time-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/11-change-failure-rate-edu.json
+++ b/v2/grafana/dashboards/11-change-failure-rate-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/11-change-failure-rate-edu.json
+++ b/v2/grafana/dashboards/11-change-failure-rate-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
+++ b/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
+++ b/v2/grafana/dashboards/12-mean-time-to-recovery-edu.json
@@ -62,7 +62,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/13-copilot-adoption-edu.json
+++ b/v2/grafana/dashboards/13-copilot-adoption-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/13-copilot-adoption-edu.json
+++ b/v2/grafana/dashboards/13-copilot-adoption-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/14-copilot-code-impact-edu.json
+++ b/v2/grafana/dashboards/14-copilot-code-impact-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/14-copilot-code-impact-edu.json
+++ b/v2/grafana/dashboards/14-copilot-code-impact-edu.json
@@ -39,7 +39,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '🌱 Synthetic Seed Data'\n    ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '🌱 Synthetic Seed Data' || COALESCE(' — ' || NULLIF(source_label, ''), '')\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
+++ b/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
@@ -61,7 +61,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT\n  CASE mode\n    WHEN 'seeded' THEN '\ud83c\udf31 Synthetic Seed Data'\n    ELSE '\ud83d\udce1 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n  END AS \"Data Source\"\nFROM data_mode\nORDER BY updated_at DESC LIMIT 1",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '\ud83c\udf31 Synthetic Seed Data' || COALESCE(' \u2014 ' || NULLIF(source_label, ''), '')\n      ELSE '\ud83d\udce1 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '\u26a0\ufe0f No data loaded \u2014 run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
+++ b/v2/grafana/dashboards/15-dora-vs-copilot-edu.json
@@ -43,7 +43,7 @@
       "id": 8,
       "type": "stat",
       "title": "",
-      "description": "Data mode banner \u2014 shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green) or synthetic seed data (amber).",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -61,7 +61,7 @@
             "type": "postgres",
             "uid": "PostgreSQL"
           },
-          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seeded' THEN '\ud83c\udf31 Synthetic Seed Data' || COALESCE(' \u2014 ' || NULLIF(source_label, ''), '')\n      ELSE '\ud83d\udce1 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '\u26a0\ufe0f No data loaded \u2014 run sync or seed'\n) AS \"Data Source\"",
+          "rawSql": "SELECT COALESCE(\n  (SELECT\n    CASE mode\n      WHEN 'seed' THEN '🌱 Synthetic Seed Data'\n      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')\n    END\n   FROM data_mode ORDER BY updated_at DESC LIMIT 1),\n  '⚠️ No data loaded — run sync or seed'\n) AS \"Data Source\"",
           "format": "table"
         }
       ],

--- a/v2/scripts/seed.ts
+++ b/v2/scripts/seed.ts
@@ -184,7 +184,7 @@ async function main() {
   await pool.query('TRUNCATE TABLE data_mode');
   await pool.query(
     `INSERT INTO data_mode (mode, source_label, source_url) VALUES ($1, $2, $3)`,
-    ['seeded', 'Synthetic seed data', null]
+    [config.dataMode, config.dataSourceLabel || 'Synthetic seed data', config.dataSourceUrl ?? null]
   );
 
   // Run bridge resolver inline (only link PRs merged before the deployment was created)

--- a/v2/setup-db.sh
+++ b/v2/setup-db.sh
@@ -4,7 +4,8 @@ source .env
 PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -p "${PG_PORT:-5432}" -U "$PG_USER" -d "$PG_DATABASE" -f src/db/schema.sql
 echo "Schema applied successfully."
 
-# Insert a default data_mode row so the dashboard banner is meaningful before the first sync/seed
+# Insert a default data_mode row so the dashboard banner is meaningful before the first sync/seed.
+# Uses DATA_MODE and DATA_SOURCE_LABEL from .env so the label reflects the configured source.
 PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -p "${PG_PORT:-5432}" -U "$PG_USER" -d "$PG_DATABASE" -c \
-  "INSERT INTO data_mode (mode, source_label) SELECT 'seed', 'No data loaded yet — run: npm run seed' WHERE NOT EXISTS (SELECT 1 FROM data_mode);"
+  "INSERT INTO data_mode (mode, source_label) SELECT '${DATA_MODE:-live}', '${DATA_SOURCE_LABEL:-Not yet synced}' WHERE NOT EXISTS (SELECT 1 FROM data_mode);"
 echo "Default data mode banner set."

--- a/v2/src/config.ts
+++ b/v2/src/config.ts
@@ -21,7 +21,7 @@ export const config = {
     password: requireEnv('PG_PASSWORD'),
   },
   port: parseInt(process.env.PORT ?? '3001', 10),
-  dataMode: (process.env.DATA_MODE ?? 'live') as 'live' | 'seeded',
+  dataMode: (process.env.DATA_MODE ?? 'live') as 'live' | 'seed',
   dataSourceLabel: process.env.DATA_SOURCE_LABEL ?? '',
   dataSourceUrl: process.env.DATA_SOURCE_URL ?? null,
 };

--- a/v2/src/index.ts
+++ b/v2/src/index.ts
@@ -2,6 +2,10 @@ import express from 'express';
 import { config } from './config';
 import syncRouter from './routes/sync';
 import statusRouter from './routes/status';
+import { getPool } from './db/connection';
+import { initDataMode } from './sync/init-data-mode';
+import { runSync } from './sync/orchestrator';
+import { createOctokit } from './github/client';
 
 const app = express();
 app.use(express.json());
@@ -15,6 +19,27 @@ app.use('/api/sync/status', statusRouter);
 
 app.listen(config.port, () => {
   console.log(`Sync server running on port ${config.port}`);
+
+  const pool = getPool();
+
+  // Always ensure data_mode has a row so the dashboard banner is never empty.
+  initDataMode(pool)
+    .then(async () => {
+      // Kick off an initial sync in the background if no successful sync has run yet.
+      const { rows } = await pool.query(
+        `SELECT COUNT(*) AS cnt FROM sync_jobs WHERE status = 'success'`
+      );
+      if (parseInt(rows[0].cnt, 10) === 0) {
+        console.log('No successful sync found — running initial sync in background...');
+        const octokit = createOctokit();
+        runSync(pool, octokit).catch((err: unknown) => {
+          console.error('Background startup sync failed:', err);
+        });
+      }
+    })
+    .catch((err: unknown) => {
+      console.error('Failed to initialize data_mode on startup:', err);
+    });
 });
 
 export default app;

--- a/v2/src/sync/init-data-mode.ts
+++ b/v2/src/sync/init-data-mode.ts
@@ -1,0 +1,15 @@
+import { Pool } from 'pg';
+import { config } from '../config.js';
+
+/**
+ * Ensures data_mode table has at least one row using the current env-var config.
+ * Only inserts when the table is empty — never overwrites a row written by a sync or seed.
+ */
+export async function initDataMode(pool: Pool): Promise<void> {
+  await pool.query(
+    `INSERT INTO data_mode (mode, source_label, source_url)
+     SELECT $1, $2, $3
+     WHERE NOT EXISTS (SELECT 1 FROM data_mode)`,
+    [config.dataMode, config.dataSourceLabel ?? null, config.dataSourceUrl ?? null]
+  );
+}

--- a/v2/tests/config.test.ts
+++ b/v2/tests/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+// Prevent dotenv from loading the .env file during tests — env vars are set
+// explicitly per-test via setRequiredEnv() and process.env manipulation.
+vi.mock('dotenv/config', () => ({}));
+
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
@@ -62,11 +66,11 @@ describe('config', () => {
     expect(config.dataMode).toBe('live');
   });
 
-  it('DATA_MODE can be set to "seeded"', async () => {
+  it('DATA_MODE can be set to "seed"', async () => {
     setRequiredEnv();
-    process.env.DATA_MODE = 'seeded';
+    process.env.DATA_MODE = 'seed';
     const { config } = await import('../src/config');
-    expect(config.dataMode).toBe('seeded');
+    expect(config.dataMode).toBe('seed');
   });
 
   it('DATA_SOURCE_LABEL is read from env', async () => {

--- a/v2/tests/init-data-mode.test.ts
+++ b/v2/tests/init-data-mode.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPool = { query: vi.fn() };
+
+vi.mock('../src/db/connection', () => ({
+  getPool: vi.fn(() => mockPool),
+}));
+
+vi.mock('../src/config', () => ({
+  config: {
+    dataMode: 'live',
+    dataSourceLabel: 'octodemo/org',
+    dataSourceUrl: 'https://github.com/octodemo',
+    port: 3001,
+  },
+}));
+
+import { initDataMode } from '../src/sync/init-data-mode';
+
+describe('initDataMode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('inserts a data_mode row using config values when table is empty', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await initDataMode(mockPool as any);
+
+    expect(mockPool.query).toHaveBeenCalledOnce();
+    const [sql, params] = mockPool.query.mock.calls[0];
+    expect(sql).toContain('WHERE NOT EXISTS');
+    expect(params).toEqual(['live', 'octodemo/org', 'https://github.com/octodemo']);
+  });
+
+  it('does not throw when the table already has a row (idempotent)', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await expect(initDataMode(mockPool as any)).resolves.toBeUndefined();
+    expect(mockPool.query).toHaveBeenCalledOnce();
+  });
+
+  it('propagates database errors', async () => {
+    mockPool.query.mockRejectedValueOnce(new Error('DB connection lost'));
+
+    await expect(initDataMode(mockPool as any)).rejects.toThrow('DB connection lost');
+  });
+});


### PR DESCRIPTION
## Problem

The dashboard banner showed **"No data"** on a fresh deploy (octodemo or any live config) because the `data_mode` table was empty until the first sync or seed run completed.

## Root Causes

1. `data_mode` table was never auto-populated — only written by a manual sync or `npm run seed`
2. All 16 dashboard SQLs had no fallback if `data_mode` was empty
3. `scripts/seed.ts` hardcoded `'seeded'` / `'Synthetic seed data'` instead of reading env vars
4. `setup-db.sh` hardcoded `'seed'` mode instead of using `${DATA_MODE}`
5. `'demo'` mode was still referenced in `.env.example` and config type despite being unused

## Changes

### New: `src/sync/init-data-mode.ts`
Idempotent `INSERT … WHERE NOT EXISTS` that writes `data_mode` from env vars (`DATA_MODE`, `DATA_SOURCE_LABEL`, `DATA_SOURCE_URL`). Only inserts when the table is empty — never overwrites a row written by a real sync.

### `src/index.ts` — startup init + auto-sync
On server startup:
1. Calls `initDataMode()` — banner is populated immediately, before any sync
2. Checks if any successful `sync_jobs` exist — if not, triggers `runSync()` in the background automatically

### All 16 `grafana/dashboards/*.json`
Banner SQL wrapped in a `COALESCE` scalar subquery:
```sql
SELECT COALESCE(
  (SELECT
    CASE mode
      WHEN 'seed' THEN '🌱 Synthetic Seed Data'
      ELSE '📡 ' || COALESCE(NULLIF(source_label, ''), 'Live Data')
    END
   FROM data_mode ORDER BY updated_at DESC LIMIT 1),
  '⚠️ No data loaded — run sync or seed'
) AS "Data Source"
```

### `scripts/seed.ts`
Uses `config.dataMode` and `config.dataSourceLabel` instead of hardcoded values — so `DATA_SOURCE_LABEL=octodemo` is respected when seeding.

### `setup-db.sh`
Uses `${DATA_MODE:-live}` and `${DATA_SOURCE_LABEL:-Not yet synced}` via env var substitution.

### `src/config.ts`
`dataMode` type narrowed from `'live' | 'seeded'` to `'live' | 'seed'`.

### `.env.example`
Removed unused `| demo` from `DATA_MODE` comment.

### `README.md`
Added **Data Sources** section explaining DORA vs Copilot API mechanics (paginated REST vs two-hop signed URL + NDJSON), incremental vs full-replace sync, and **Database Schema** section with three Mermaid ER diagrams.

### `tests/config.test.ts`
- Mocks `dotenv/config` to prevent a local `.env` file from interfering with missing-token tests
- Updated `'seeded'` → `'seed'` test case

### `tests/init-data-mode.test.ts` *(new)*
3 unit tests: inserts with correct params, is idempotent, propagates DB errors.

## Test Results

```
Test Files  15 passed (15)
     Tests  245 passed (245)
```

## Screenshots

**Before** (empty `data_mode`): banner showed blank / "No data"  
**After** (seeded): `🌱 Synthetic Seed Data`  
**After** (live octodemo): `📡 octodemo/octocat_supply-fictional-octo-giggle`  
**Fallback** (empty table): `⚠️ No data loaded — run sync or seed`
