### PR TITLE
fix(v3): rebuild Enterprise & Organization Copilot Leading dashboards (PR-metrics + code-review)

### DIFF
--- a/enterprise.json
+++ b/enterprise.json
@@ -1,0 +1,2788 @@
+{
+  "uid": "edu-per-user-copilot",
+  "title": "👤 Per-User Copilot Metrics [Edu]",
+  "description": "Shows per-user Copilot activity metrics — interactions, code volume, acceptance rate, feature adoption, and daily trends — filtered to a selected user via the variable picker.",
+  "schemaVersion": 36,
+  "version": 7,
+  "refresh": "5m",
+  "time": {
+    "from": "now-28d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "templating": {
+    "list": [
+      {
+        "name": "user_login",
+        "label": "User",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "PostgreSQL"
+        },
+        "definition": "SELECT DISTINCT user_login FROM copilot_user_daily ORDER BY user_login",
+        "query": "SELECT DISTINCT user_login FROM copilot_user_daily ORDER BY user_login",
+        "refresh": 1,
+        "sort": 1,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "",
+      "description": "Data mode banner — shows whether this dashboard displays live GitHub data (green), synthetic seed data (amber), or demo data (blue).",
+      "gridPos": {
+        "x": 0,
+        "y": 2,
+        "w": 24,
+        "h": 2
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE('Live: ' || (SELECT value FROM app_config WHERE key = 'org') || '/' || (SELECT value FROM app_config WHERE key = 'repo'), 'Not yet synced') AS \"Data Source\"",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "regex",
+              "options": {
+                "pattern": "Live Data",
+                "result": {
+                  "color": "#73BF69",
+                  "index": 0
+                }
+              }
+            },
+            {
+              "type": "regex",
+              "options": {
+                "pattern": "Seed Data",
+                "result": {
+                  "color": "#FA6400",
+                  "index": 1
+                }
+              }
+            },
+            {
+              "type": "regex",
+              "options": {
+                "pattern": "Demo Environment",
+                "result": {
+                  "color": "#5794F2",
+                  "index": 2
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "transparent": false
+    },
+    {
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 24,
+        "h": 11
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "# 👤 Per-User Copilot Metrics\n\n**Supplementary Metrics — Individual Developer Copilot Activity**\n\nUse the **User** dropdown above to select a developer and explore their Copilot activity across the selected time range.\n\n## What it Measures\nThis dashboard surfaces per-user data from the GitHub Copilot Metrics Reports API (users-28-day report). It shows how actively a specific developer is using Copilot — broken down by interaction volume, lines of code suggested and accepted, acceptance rate, and which Copilot surfaces they engage with.\n\n⚠️ **Important:** This dashboard contains Copilot activity metrics only (interactions, code generation, lines accepted, and feature adoption). The GitHub Copilot Metrics Reports API does not provide per-user pull request telemetry, so this dashboard does not include PR-related metrics or per-PR attribution.\n\n## Why it Matters\nOrg-level dashboards show aggregate trends, but individual coaching conversations require user-level context. This dashboard helps engineering managers and developer coaches:\n- Identify developers who have a seat but are not actively using Copilot\n- Distinguish low-acceptance-rate users (may need prompting guidance) from high-volume users\n- Understand feature adoption — does the developer use only completions, or also chat, CLI, agent mode, and code review?"
+      },
+      "transparent": true,
+      "description": "Per-User Copilot Metrics — individual activity, code volume, acceptance rate, and feature adoption."
+    },
+    {
+      "id": 320,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 15,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "Total Interactions (28d) - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": [],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "backgroundColor": "#E8F2FF"
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Total Interactions (28d)",
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 24,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT SUM(user_initiated_interaction_count) AS \"Total Interactions (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "Source: Copilot Metrics Reports API: `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `user_initiated_interaction_count` | Tables: `copilot_user_daily`"
+    },
+    {
+      "id": 300,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 25,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\nCopilot Metrics Reports API (2026-03-10): `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `user_initiated_interaction_count`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nSum of `user_initiated_interaction_count` for the selected user across the Grafana time range. Each row represents one calendar day. An interaction is any user-driven Copilot event: accepting a suggestion, sending a chat message, running a CLI command, etc.\n\n### How to Interpret\n\n| Healthy Signal | Action Needed |\n|---|---|\n| Growing week-over-week | Flat or declining — explore blockers |\n\n### SQL Query\n\n```sql\nSELECT SUM(user_initiated_interaction_count) AS \"Total Interactions (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n```"
+      }
+    },
+    {
+      "id": 321,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 39,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 201,
+      "type": "row",
+      "title": "Code Generation Activities (28d) - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 43,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Code Generation Activities (28d)",
+      "gridPos": {
+        "x": 0,
+        "y": 40,
+        "w": 24,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT SUM(code_generation_activity_count) AS \"Code Generation Activities (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "Source: `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `code_generation_activity_count` | Tables: `copilot_user_daily`"
+    },
+    {
+      "id": 301,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 44,
+        "w": 24,
+        "h": 7
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `code_generation_activity_count`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nSum of `code_generation_activity_count` for the selected user. This counts Copilot code generation events — completions shown to the user, regardless of whether they were accepted.\n\n### SQL Query\n\n```sql\nSELECT SUM(code_generation_activity_count) AS \"Code Generation Activities (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n```"
+      }
+    },
+    {
+      "id": 325,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 202,
+      "type": "row",
+      "title": "Code Acceptance Activities (28d) - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Code Acceptance Activities (28d)",
+      "gridPos": {
+        "x": 0,
+        "y": 59,
+        "w": 24,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT SUM(code_acceptance_activity_count) AS \"Code Acceptance Activities (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "Source: `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `code_acceptance_activity_count` | Tables: `copilot_user_daily`"
+    },
+    {
+      "id": 302,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 63,
+        "w": 24,
+        "h": 7
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `code_acceptance_activity_count`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nSum of `code_acceptance_activity_count` for the selected user. This counts the number of times the user explicitly accepted a Copilot code suggestion (Tab / ).\n\n### SQL Query\n\n```sql\nSELECT SUM(code_acceptance_activity_count) AS \"Code Acceptance Activities (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n```"
+      }
+    },
+    {
+      "id": 322,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 77,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 203,
+      "type": "row",
+      "title": "Active Days (28d) - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 77,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Active Days (28d)",
+      "gridPos": {
+        "x": 0,
+        "y": 78,
+        "w": 24,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COUNT(DISTINCT day) AS \"Active Days (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 7
+              },
+              {
+                "color": "green",
+                "value": 15
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "Source: `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` | Tables: `copilot_user_daily`"
+    },
+    {
+      "id": 303,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 82,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nCount of distinct calendar days where the user has a row in `copilot_user_daily`. The sync stores one row per user per day only when the user had Copilot activity. Days with no activity have no row.\n\n### How to Interpret\n\n| Healthy Signal | Action Needed |\n|---|---|\n| Most days in window | Gaps — check for availability or disengagement |\n\n### SQL Query\n\n```sql\nSELECT COUNT(DISTINCT day) AS \"Active Days (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n```"
+      }
+    },
+    {
+      "id": 323,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 134,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 206,
+      "type": "row",
+      "title": "Lines Suggested vs Accepted - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 134,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Lines Suggested vs Accepted (28d)",
+      "gridPos": {
+        "x": 0,
+        "y": 135,
+        "w": 24,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  COALESCE(SUM(loc_suggested_to_add_sum), 0) AS \"Lines Suggested\",\n  COALESCE(SUM(loc_added_sum), 0) AS \"Lines Accepted\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lines Suggested"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lines Accepted"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "Source: `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `loc_suggested_to_add_sum`, `loc_added_sum` | Tables: `copilot_user_daily`. Lines Suggested = total lines Copilot offered. Lines Accepted = total lines the user kept. Agent/chat mode can produce accepted lines without inline suggestions."
+    },
+    {
+      "id": 306,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 139,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `loc_suggested_to_add_sum`, `loc_added_sum`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nShows raw line-of-code counts side by side:\n- **Lines Suggested** — total lines Copilot offered (inline completions)\n- **Lines Accepted** — total lines the user kept from Copilot\n\n⚠️ **Why not a percentage?** Agent mode, chat, and edit mode write lines directly (`loc_added_sum`) without going through the inline suggestion pipeline (`loc_suggested_to_add_sum`). For heavy agent/chat users, accepted lines can far exceed suggested lines — making a percentage misleading (often >100% or even millions of %). Showing raw counts avoids this distortion.\n\n### How to Interpret\n\n| Healthy Signal | Action Needed |\n|---|---|\n| Accepted close to or below Suggested | Accepted >> Suggested — agent/chat mode dominates (not inherently bad) |\n\n### SQL Query\n\n```sql\nSELECT\n  COALESCE(SUM(loc_suggested_to_add_sum), 0) AS \"Lines Suggested\",\n  COALESCE(SUM(loc_added_sum), 0) AS \"Lines Accepted\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n```"
+      }
+    },
+    {
+      "id": 324,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 153,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 207,
+      "type": "row",
+      "title": "Feature Adoption - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 153,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 10,
+      "type": "table",
+      "title": "Feature Adoption (days used in window)",
+      "gridPos": {
+        "x": 0,
+        "y": 154,
+        "w": 24,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  SUM(CASE WHEN used_agent THEN 1 ELSE 0 END) AS \"Agent Mode (IDE)\",\n  SUM(CASE WHEN used_chat THEN 1 ELSE 0 END) AS \"Chat\",\n  SUM(CASE WHEN used_cli THEN 1 ELSE 0 END) AS \"CLI\",\n  SUM(CASE WHEN used_copilot_code_review_active THEN 1 ELSE 0 END) AS \"Code Review (Active)\",\n  SUM(CASE WHEN used_copilot_code_review_passive THEN 1 ELSE 0 END) AS \"Code Review (Passive)\",\n  SUM(CASE WHEN used_copilot_coding_agent THEN 1 ELSE 0 END) AS \"Cloud Agent\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "displayMode": "color-background",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-gray",
+                "value": null
+              },
+              {
+                "color": "#FF6B6B",
+                "value": 0
+              },
+              {
+                "color": "#FFA94D",
+                "value": 1
+              },
+              {
+                "color": "#FFD93D",
+                "value": 10
+              },
+              {
+                "color": "#95E1D3",
+                "value": 15
+              },
+              {
+                "color": "#52B788",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Agent Mode (IDE)"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Chat"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CLI"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Code Review (Active)"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Code Review (Passive)"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cloud Agent"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "description": "Source: `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `used_agent`, `used_chat`, `used_cli`, `used_copilot_code_review_active`, `used_copilot_code_review_passive`, `used_copilot_coding_agent` | Tables: `copilot_user_daily`"
+    },
+    {
+      "id": 307,
+      "type": "text",
+      "title": "",
+      "transparent": false,
+      "gridPos": {
+        "x": 0,
+        "y": 159,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `used_agent`, `used_chat`, `used_cli`, `used_copilot_code_review_active`, `used_copilot_code_review_passive`, `used_copilot_coding_agent`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nEach boolean column is converted into a day count using `SUM(CASE WHEN ... THEN 1 ELSE 0 END)` across all rows in the selected time range. The result is the number of days in the window where the selected user used each surface at least once.\n\n### How to Interpret\n\n| Healthy Signal | Action Needed |\n|---|---|\n| Multiple surfaces (✅ on several) | Only completions — expand use-case awareness |\n\n### Feature Definitions\n\n| Feature | Column | Set `true` when... |\n|---|---|---|\n| **Agent Mode (IDE)** | `used_agent` | Developer used Copilot agent mode inside an IDE |\n| **Chat** | `used_chat` | Developer used Copilot Chat (IDE sidebar or web) |\n| **CLI** | `used_cli` | Developer used GitHub Copilot CLI (`gh copilot`) |\n| **Code Review (Active)** | `used_copilot_code_review_active` | Developer intentionally assigned Copilot as reviewer, re-requested a CCR review, or applied a CCR suggestion |\n| **Code Review (Passive)** | `used_copilot_code_review_passive` | Copilot auto-reviewed a PR via repo policy; developer did not interact. Active takes precedence if both occur. |\n| **Cloud Agent** | `used_copilot_coding_agent` | Developer assigned Copilot to a GitHub Issue or mentioned @copilot in a PR |\n\n### SQL Query\n\n```sql\nSELECT\n  SUM(CASE WHEN used_agent THEN 1 ELSE 0 END) AS \"Agent Mode (IDE)\",\n  SUM(CASE WHEN used_chat THEN 1 ELSE 0 END) AS \"Chat\",\n  SUM(CASE WHEN used_cli THEN 1 ELSE 0 END) AS \"CLI\",\n  SUM(CASE WHEN used_copilot_code_review_active THEN 1 ELSE 0 END) AS \"Code Review (Active)\",\n  SUM(CASE WHEN used_copilot_code_review_passive THEN 1 ELSE 0 END) AS \"Code Review (Passive)\",\n  SUM(CASE WHEN used_copilot_coding_agent THEN 1 ELSE 0 END) AS \"Cloud Agent\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n```"
+      }
+    },
+    {
+      "id": 319,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 173,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 208,
+      "type": "row",
+      "title": "Daily Activity Trend - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 191,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Daily Activity Trend — Lines Accepted",
+      "gridPos": {
+        "x": 0,
+        "y": 192,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  day AS time,\n  COALESCE(loc_added_sum, 0) AS \"Lines Accepted\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\nORDER BY day",
+          "format": "time_series"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  day AS time,\n  COALESCE(loc_suggested_to_add_sum, 0) AS \"Lines Suggested\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\nORDER BY day",
+          "format": "time_series"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  day AS time,\n  COALESCE(loc_deleted_sum, 0) AS \"Lines Deleted\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\nORDER BY day",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lines Suggested"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    4,
+                    4
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lines Accepted"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lines Deleted"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    4,
+                    4
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "description": "Source: `GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `loc_added_sum`, `loc_suggested_to_add_sum`, `loc_deleted_sum` | Tables: `copilot_user_daily`"
+    },
+    {
+      "id": 317,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "x": 0,
+        "y": 198,
+        "w": 24,
+        "h": 14
+      },
+      "datasource": null,
+      "targets": [],
+      "fieldConfig": {
+        "overrides": [],
+        "defaults": {}
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `loc_added_sum`, `loc_suggested_to_add_sum`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nTwo time series plotted per calendar day:\n- **Lines Accepted** (solid green) — `loc_added_sum` — lines accepted by the user that day\n- **Lines Suggested** (dashed blue) — `loc_suggested_to_add_sum` — lines Copilot offered\n\nThe gap between the two lines is the volume of rejected suggestions. Shrinking gap = improving acceptance rate.\n\n### SQL Query\n\n```sql\nSELECT day AS time, COALESCE(loc_added_sum, 0) AS \"Lines Accepted\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 17,
+      "type": "stat",
+      "title": "Lines Deleted (28d)",
+      "description": "Lines deleted from the editor by Copilot (agent/edit mode direct file writes). Source: `loc_deleted_sum` | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 0,
+        "y": 219,
+        "w": 12,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT SUM(loc_deleted_sum) AS \"Lines Deleted (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 18,
+      "type": "stat",
+      "title": "Net Lines Changed (28d)",
+      "description": "Net lines changed by Copilot (lines added minus lines deleted). Positive = net new code. Source: `loc_added_sum - loc_deleted_sum` | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 12,
+        "y": 219,
+        "w": 12,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT SUM(loc_added_sum) - COALESCE(SUM(loc_deleted_sum), 0) AS \"Net Lines Changed (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 321,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 237,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 330,
+      "type": "row",
+      "title": "Top Languages Used with Copilot - Learning Guide",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 241,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 19,
+      "type": "table",
+      "title": "Top Languages Used with Copilot",
+      "description": "Languages used with Copilot, ranked by lines accepted. Acceptance Rate > 100% is expected when agent/CLI modes write more lines than were offered as completion suggestions — see the Learning Guide. Source: `totals_by_language_feature` JSONB | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 0,
+        "y": 242,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  lang->>'language' AS \"Language\",\n  SUM((lang->>'loc_added_sum')::bigint) AS \"Lines Accepted\",\n  ROUND(\n    SUM((lang->>'loc_added_sum')::bigint)::numeric\n    / NULLIF(SUM((lang->>'loc_suggested_to_add_sum')::bigint), 0) * 100, 1\n  ) AS \"Acceptance Rate (%)\"\nFROM copilot_user_daily,\n  jsonb_array_elements(totals_by_language_feature) AS lang\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_language_feature IS NOT NULL\nGROUP BY 1\nORDER BY 2 DESC NULLS LAST\nLIMIT 10",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lines Accepted"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "lcd-gauge"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Acceptance Rate (%)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "custom.width",
+                "value": 180
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 20
+                    },
+                    {
+                      "color": "green",
+                      "value": 30
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      }
+    },
+    {
+      "id": 312,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 248,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `totals_by_language_feature`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nUnnests the `totals_by_language_feature` JSONB array with `jsonb_array_elements()`. Each element represents one language+feature combination. Groups by `language` (summing across features) to compute:\n\n- **Lines Accepted** — `SUM(loc_added_sum)` — total Copilot-accepted lines in this language\n- **Acceptance Rate (%)** — `SUM(loc_added_sum) / SUM(loc_suggested_to_add_sum)` per language\n\nSorted by Lines Accepted descending; capped at top 10 languages.\n\n### SQL Query\n\n```sql\nSELECT\n  lang->>'language' AS \"Language\",\n  SUM((lang->>'loc_added_sum')::bigint) AS \"Lines Accepted\",\n  ROUND(\n    SUM((lang->>'loc_added_sum')::bigint)::numeric\n    / NULLIF(SUM((lang->>'loc_suggested_to_add_sum')::bigint), 0) * 100, 1\n  ) AS \"Acceptance Rate (%)\"\nFROM copilot_user_daily,\n  jsonb_array_elements(totals_by_language_feature) AS lang\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_language_feature IS NOT NULL\nGROUP BY 1\nORDER BY 2 DESC NULLS LAST\nLIMIT 10\n```"
+      }
+    },
+    {
+      "id": 322,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 263,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 214,
+      "type": "row",
+      "title": "Feature Activity Breakdown - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 267,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 20,
+      "type": "table",
+      "title": "Feature Activity Breakdown",
+      "description": "Copilot interactions and lines accepted by feature surface (completions, inline_chat, chat_panel, agent_edit). Source: `totals_by_feature` JSONB | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 0,
+        "y": 268,
+        "w": 24,
+        "h": 7
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  feat->>'feature' AS \"Feature\",\n  SUM((feat->>'user_initiated_interaction_count')::bigint) AS \"Interactions\",\n  SUM((feat->>'loc_added_sum')::bigint) AS \"Lines Accepted\"\nFROM copilot_user_daily,\n  jsonb_array_elements(totals_by_feature) AS feat\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_feature IS NOT NULL\nGROUP BY 1\nORDER BY 2 DESC NULLS LAST",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Interactions"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "lcd-gauge"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lines Accepted"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "lcd-gauge"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "blue",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      }
+    },
+    {
+      "id": 313,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 275,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `totals_by_feature`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nUnnests the `totals_by_feature` JSONB array and groups by `feature` name. Shows interaction volume and lines accepted per Copilot surface.\n\nTypical feature values:\n- `completions` — inline code completions triggered automatically as the developer types\n- `inline_chat` — code suggestions via inline chat (keyboard shortcut in the editor)\n- `chat_panel` — interactions in the Copilot Chat sidebar\n- `agent_edit` — agent or edit mode direct file writes (not counted in suggestion-based metrics)\n\n### SQL Query\n\n```sql\nSELECT\n  feat->>'feature' AS \"Feature\",\n  SUM((feat->>'user_initiated_interaction_count')::bigint) AS \"Interactions\",\n  SUM((feat->>'loc_added_sum')::bigint) AS \"Lines Accepted\"\nFROM copilot_user_daily,\n  jsonb_array_elements(totals_by_feature) AS feat\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_feature IS NOT NULL\nGROUP BY 1\nORDER BY 2 DESC NULLS LAST\n```"
+      }
+    },
+    {
+      "id": 323,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 289,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 215,
+      "type": "row",
+      "title": "IDE Usage - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 293,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "table",
+      "title": "IDE Usage",
+      "description": "Which IDE(s) this developer uses Copilot in. Source: `totals_by_ide` JSONB | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 0,
+        "y": 294,
+        "w": 24,
+        "h": 6
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  ide_row->>'ide' AS \"IDE\",\n  SUM((ide_row->>'user_initiated_interaction_count')::bigint) AS \"Interactions\",\n  SUM((ide_row->>'loc_added_sum')::bigint) AS \"Lines Accepted\"\nFROM copilot_user_daily,\n  jsonb_array_elements(totals_by_ide) AS ide_row\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_ide IS NOT NULL\nGROUP BY 1\nORDER BY 2 DESC NULLS LAST",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Interactions"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "lcd-gauge"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lines Accepted"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "lcd-gauge"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "blue",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      }
+    },
+    {
+      "id": 314,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 300,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `totals_by_ide`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nUnnests the `totals_by_ide` JSONB array and groups by `ide` name. Shows interactions and accepted lines per IDE.\n\nTypical IDE values: `vscode`, `jetbrains`, `vim`, `neovim`, `visual_studio`, `xcode`, `azure_data_studio`.\n\n### SQL Query\n\n```sql\nSELECT\n  ide_row->>'ide' AS \"IDE\",\n  SUM((ide_row->>'user_initiated_interaction_count')::bigint) AS \"Interactions\",\n  SUM((ide_row->>'loc_added_sum')::bigint) AS \"Lines Accepted\"\nFROM copilot_user_daily,\n  jsonb_array_elements(totals_by_ide) AS ide_row\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_ide IS NOT NULL\nGROUP BY 1\nORDER BY 2 DESC NULLS LAST\n```"
+      }
+    },
+    {
+      "id": 324,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 314,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 216,
+      "type": "row",
+      "title": "AI Model & Chat Mode Usage - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 318,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 22,
+      "type": "table",
+      "title": "AI Model Usage (Chat)",
+      "description": "Which AI models this user's chat interactions use (chat only, not completions). Source: `totals_by_model_feature` JSONB | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 0,
+        "y": 319,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  m->>'model' AS \"Model\",\n  SUM((m->>'user_initiated_interaction_count')::bigint) AS \"Interactions\"\nFROM copilot_user_daily,\n  jsonb_array_elements(totals_by_model_feature) AS m\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_model_feature IS NOT NULL\nGROUP BY 1\nORDER BY 2 DESC NULLS LAST",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Interactions"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "lcd-gauge"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      }
+    },
+    {
+      "id": 26,
+      "type": "table",
+      "title": "Chat Mode Breakdown",
+      "description": "Chat panel interactions by mode (ask, edit, agent, plan). Source: `totals_by_model_feature` JSONB → `feature` field | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 12,
+        "y": 319,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  m->>'feature' AS \"Chat Mode\",\n  SUM((m->>'user_initiated_interaction_count')::bigint) AS \"Interactions\"\nFROM copilot_user_daily,\n  jsonb_array_elements(totals_by_model_feature) AS m\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_model_feature IS NOT NULL\nGROUP BY 1\nORDER BY 2 DESC NULLS LAST",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Interactions"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "lcd-gauge"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "purple",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      }
+    },
+    {
+      "id": 315,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 327,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `totals_by_model_feature`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\nUnnests the `totals_by_model_feature` JSONB array. Per the API docs, this field covers **chat activity only** (not inline completions). Each element has a `model` and a `feature` (chat mode).\n\n**AI Model Usage (left)** — groups by `model`. When auto-select is on, the actual model used (not \"Auto\") is attributed.\n\n**Chat Mode Breakdown (right)** — groups by `feature`. Mode values:\n- `ask` — question-and-answer in the chat sidebar\n- `edit` — Copilot edit mode (modifies the current file)\n- `agent` — multi-step agent mode spanning multiple files\n- `plan` — planning mode (proposes a plan before coding)\n- `custom` — custom agent extensions\n\n### SQL Queries\n\n```sql\n-- AI Model Usage\nSELECT m->>'model' AS \"Model\",\n  SUM((m->>'user_initiated_interaction_count')::bigint) AS \"Interactions\"\nFROM copilot_user_daily, jsonb_array_elements(totals_by_model_feature) AS m\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_model_feature IS NOT NULL\nGROUP BY 1 ORDER BY 2 DESC NULLS LAST\n\n-- Chat Mode Breakdown\nSELECT m->>'feature' AS \"Chat Mode\",\n  SUM((m->>'user_initiated_interaction_count')::bigint) AS \"Interactions\"\nFROM copilot_user_daily, jsonb_array_elements(totals_by_model_feature) AS m\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_model_feature IS NOT NULL\nGROUP BY 1 ORDER BY 2 DESC NULLS LAST\n```"
+      }
+    },
+    {
+      "id": 325,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 341,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 217,
+      "type": "row",
+      "title": "CLI Usage - Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 345,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 23,
+      "type": "stat",
+      "title": "CLI Sessions (28d)",
+      "description": "Distinct `gh copilot` CLI sessions. Source: `totals_by_cli` (JSON object, not array) → `session_count` | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 0,
+        "y": 346,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE(SUM((totals_by_cli->>'session_count')::bigint), 0) AS \"CLI Sessions (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 24,
+      "type": "stat",
+      "title": "CLI Requests (28d)",
+      "description": "Total CLI requests (user prompts + automated agentic follow-ups). Source: `totals_by_cli.request_count` | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 8,
+        "y": 346,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE(SUM((totals_by_cli->>'request_count')::bigint), 0) AS \"CLI Requests (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 25,
+      "type": "stat",
+      "title": "CLI Prompts (28d)",
+      "description": "User-initiated CLI prompts/commands only (excludes automated agentic follow-up calls). Source: `totals_by_cli.prompt_count` | Table: `copilot_user_daily`",
+      "gridPos": {
+        "x": 16,
+        "y": 346,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE(SUM((totals_by_cli->>'prompt_count')::bigint), 0) AS \"CLI Prompts (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 331,
+      "type": "stat",
+        "title": "CLI Output Tokens (28d)",
+        "description": "Total CLI output tokens over the selected time range.",
+      "gridPos": {
+        "x": 0,
+        "y": 350,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE(SUM((totals_by_cli->'token_usage'->>'output_tokens_sum')::bigint), 0) AS \"CLI Output Tokens (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 332,
+      "type": "stat",
+      "title": "CLI Prompt Tokens (28d)",
+      "description": "Total CLI prompt tokens over the selected time range.",
+      "gridPos": {
+        "x": 8,
+        "y": 350,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE(SUM((totals_by_cli->'token_usage'->>'prompt_tokens_sum')::bigint), 0) AS \"CLI Prompt Tokens (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 333,
+      "type": "stat",
+      "title": "CLI Avg Tokens/Request",
+      "description": "Average total CLI tokens per request over the selected time range.",
+      "gridPos": {
+        "x": 16,
+        "y": 350,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE(ROUND(\n  (COALESCE(SUM((totals_by_cli->'token_usage'->>'output_tokens_sum')::numeric), 0)\n  + COALESCE(SUM((totals_by_cli->'token_usage'->>'prompt_tokens_sum')::numeric), 0))\n  / NULLIF(COALESCE(SUM((totals_by_cli->>'request_count')::numeric), 0), 0),\n  1\n), 0) AS \"CLI Avg Tokens/Request\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 316,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 362,
+        "w": 24,
+        "h": 18
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [→ docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` → `totals_by_cli`\n\n### Database Table(s)\n\n`copilot_user_daily` — one row per user per day.\n\n### Important: Daily Values, Not Rolling Totals\n\nDespite the report name (`users-28-day`), each NDJSON line returned by the API represents **a single calendar day's activity** for one user — not a 28-day rolling aggregate. The `28-day` in the endpoint name refers to the report's time window (it returns the last 28 days of data), not the aggregation period of each row.\n\n**Evidence:** Values fluctuate significantly day-to-day (e.g. a user may have 138 requests one day and 1,219 the next). If these were rolling 28-day totals, values would be far more stable. Additionally, the table contains exactly one row per user per active day.\n\nBecause each row is a **daily snapshot**, the `SUM()` across the selected time range correctly produces the total for that period — there is no double-counting.\n\n### How It's Calculated\n\n`totals_by_cli` is a JSON object on each daily row. These CLI cards sum daily values across the selected time range:\n\n- **CLI Sessions** — `session_count` — distinct `gh copilot` invocations, summed\n- **CLI Requests** — `request_count` — total API calls, including automated follow-ups\n- **CLI Prompts** — `prompt_count` — user-typed prompts only\n- **CLI Output Tokens** — `token_usage.output_tokens_sum` — total generated tokens\n- **CLI Prompt Tokens** — `token_usage.prompt_tokens_sum` — total prompt tokens sent\n- **CLI Avg Tokens/Request** — `(output_tokens_sum + prompt_tokens_sum) / request_count`\n\nToken counts can be large (hundreds of millions over 28 days for active CLI/agent-mode users) because each request sends full file context as prompt tokens.\n\nRows where `totals_by_cli IS NULL` (user had no CLI activity that day) are excluded.\n\n### SQL Query\n\n```sql\nSELECT\n  COALESCE(SUM((totals_by_cli->>'session_count')::bigint), 0) AS \"Sessions\",\n  COALESCE(SUM((totals_by_cli->>'request_count')::bigint), 0) AS \"Requests\",\n  COALESCE(SUM((totals_by_cli->>'prompt_count')::bigint), 0) AS \"Prompts\",\n  COALESCE(SUM((totals_by_cli->'token_usage'->>'output_tokens_sum')::bigint), 0) AS \"Output Tokens\",\n  COALESCE(SUM((totals_by_cli->'token_usage'->>'prompt_tokens_sum')::bigint), 0) AS \"Prompt Tokens\",\n  COALESCE(ROUND(\n    (COALESCE(SUM((totals_by_cli->'token_usage'->>'output_tokens_sum')::numeric), 0)\n    + COALESCE(SUM((totals_by_cli->'token_usage'->>'prompt_tokens_sum')::numeric), 0))\n    / NULLIF(COALESCE(SUM((totals_by_cli->>'request_count')::numeric), 0), 0),\n    1\n  ), 0) AS \"Avg Tokens/Request\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL\n```"
+      },
+      "description": "How CLI usage metrics are sourced and aggregated for the selected time range."
+    },
+    {
+      "id": 334,
+      "type": "timeseries",
+      "title": "Daily CLI Usage Trend",
+      "description": "Daily trend of CLI sessions, requests, prompts, and token usage for the selected user. Source: `totals_by_cli` from `copilot_user_daily`.",
+      "gridPos": {
+        "x": 0,
+        "y": 354,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  day AS time,\n  COALESCE((totals_by_cli->>'session_count')::bigint, 0) AS \"Sessions\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL\nORDER BY day",
+          "format": "time_series"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  day AS time,\n  COALESCE((totals_by_cli->>'request_count')::bigint, 0) AS \"Requests\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL\nORDER BY day",
+          "format": "time_series"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  day AS time,\n  COALESCE((totals_by_cli->>'prompt_count')::bigint, 0) AS \"Prompts\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL\nORDER BY day",
+          "format": "time_series"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  day AS time,\n  COALESCE((totals_by_cli->'token_usage'->>'output_tokens_sum')::bigint, 0) AS \"Output Tokens\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL\nORDER BY day",
+          "format": "time_series"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  day AS time,\n  COALESCE((totals_by_cli->'token_usage'->>'prompt_tokens_sum')::bigint, 0) AS \"Prompt Tokens\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  AND totals_by_cli IS NOT NULL\nORDER BY day",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false,
+            "axisSoftMin": 0
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Sessions" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#5794F2", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Requests" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Prompts" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Output Tokens" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#B877D9", "mode": "fixed" } },
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "custom.lineStyle", "value": { "dash": [4, 4], "fill": "dash" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Prompt Tokens" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#F2495C", "mode": "fixed" } },
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "custom.lineStyle", "value": { "dash": [4, 4], "fill": "dash" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 326,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 380,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 209,
+      "type": "row",
+      "title": "PR Review Time",
+      "gridPos": {
+        "x": 0,
+        "y": 384,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Median PR Review Time (hrs)",
+      "gridPos": {
+        "x": 0,
+        "y": 385,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE(ROUND(\n  PERCENTILE_CONT(0.5) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0\n  )::numeric, 1\n), 0) AS \"Median PR Review Time (hrs)\"\nFROM pull_requests pr\nWHERE pr.merged_by->>'login' = '${user_login}'\n  AND pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 24
+              },
+              {
+                "color": "red",
+                "value": 72
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "Source: `pull_requests` table | Filtered by `merged_by_login = user` | Tables: `pull_requests`"
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "P90 PR Review Time (hrs)",
+      "gridPos": {
+        "x": 8,
+        "y": 385,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COALESCE(ROUND(\n  PERCENTILE_CONT(0.9) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0\n  )::numeric, 1\n), 0) AS \"P90 PR Review Time (hrs)\"\nFROM pull_requests pr\nWHERE pr.merged_by->>'login' = '${user_login}'\n  AND pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 24
+              },
+              {
+                "color": "red",
+                "value": 72
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "Source: `pull_requests` table | Filtered by `merged_by_login = user` | Tables: `pull_requests`"
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "PRs Merged",
+      "gridPos": {
+        "x": 16,
+        "y": 385,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT COUNT(*) AS \"PRs Merged\"\nFROM pull_requests pr\nWHERE pr.merged_by->>'login' = '${user_login}'\n  AND pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "Source: `pull_requests` table | Filtered by `merged_by_login = user` | Tables: `pull_requests`"
+    },
+    {
+      "id": 309,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 389,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source\n\nGitHub REST API — Pull Requests endpoint.\n\n### Database Table(s)\n\n`pull_requests`\n\n### How It's Calculated\n\n**PR Review Time** = `merged_at - created_at` — elapsed time from when a PR was opened to when it was merged.\n\nFiltered by `merged_by->>'login' = user` — **PRs this developer personally merged**, regardless of who wrote the code. Captures both their own PRs and Copilot-agent PRs they reviewed and shipped.\n\n- **Median (P50)** — half of PRs merged faster, half slower. Resistant to outliers.\n- **P90** — 90% of PRs merged within this time. Highlights the slow tail.\n- **Count** — total PRs merged in the selected window.\n\n### SQL Query\n\n```sql\nSELECT COALESCE(ROUND(\n  PERCENTILE_CONT(0.5) WITHIN GROUP (\n    ORDER BY EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0\n  )::numeric, 1\n), 0) AS \"Median PR Review Time (hrs)\"\nFROM pull_requests pr\nWHERE pr.merged_by->>'login' = '${user_login}'\n  AND pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\n```"
+      }
+    },
+    {
+      "id": 327,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 403,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 210,
+      "type": "row",
+      "title": "Weekly PR Review Time Trend",
+      "gridPos": {
+        "x": 0,
+        "y": 407,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Weekly PR Review Time Trend",
+      "gridPos": {
+        "x": 0,
+        "y": 400,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  date_trunc('week', pr.merged_at) AS time,\n  ROUND(\n    PERCENTILE_CONT(0.5) WITHIN GROUP (\n      ORDER BY EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0\n    )::numeric, 1\n  ) AS \"Median Review Time (hrs)\"\nFROM pull_requests pr\nWHERE pr.merged_by->>'login' = '${user_login}'\n  AND pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 1",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "description": "Source: `pull_requests` table | Filtered by `merged_by_login = user` | Tables: `pull_requests`"
+    },
+    {
+      "id": 310,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 408,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source\n\nGitHub REST API — Pull Requests endpoint.\n\n### Database Table(s)\n\n`pull_requests`\n\n### How It's Calculated\n\nWeekly median of `merged_at - created_at` for PRs merged by this user. Bucketed by `date_trunc('week', merged_at)`.\n\n### SQL Query\n\n```sql\nSELECT\n  date_trunc('week', pr.merged_at) AS time,\n  ROUND(\n    PERCENTILE_CONT(0.5) WITHIN GROUP (\n      ORDER BY EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0\n    )::numeric, 1\n  ) AS \"Median Review Time (hrs)\"\nFROM pull_requests pr\nWHERE pr.merged_by->>'login' = '${user_login}'\n  AND pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 1\n```"
+      }
+    },
+    {
+      "id": 329,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 427,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 211,
+      "type": "row",
+      "title": "Recent PRs",
+      "gridPos": {
+        "x": 0,
+        "y": 431,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 16,
+      "type": "table",
+      "title": "Recent PRs Merged by This User",
+      "gridPos": {
+        "x": 0,
+        "y": 432,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "rawSql": "SELECT\n  pr.number AS \"PR #\",\n  pr.title AS \"Title\",\n  pr.user->>'login' AS \"Author Login\",\n  CASE\n    WHEN pr.user->>'login' = 'Copilot' THEN 'Copilot'\n    WHEN pr.user->>'login' LIKE '%[bot]' THEN 'Bot'\n    ELSE 'Human'\n  END AS \"Author Type\",\n  ROUND((EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0)::numeric, 1) AS \"Review Time (hrs)\",\n  pr.created_at AS \"Opened\",\n  pr.merged_at AS \"Merged\"\nFROM pull_requests pr\nWHERE pr.merged_by->>'login' = '${user_login}'\n  AND pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nORDER BY pr.merged_at DESC\nLIMIT 25",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PR #"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Review Time (hrs)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "h"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "blue",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 24
+                    },
+                    {
+                      "color": "red",
+                      "value": 72
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "description": "Source: `pull_requests` table | Filtered by `merged_by_login = user` | Tables: `pull_requests`"
+    },
+    {
+      "id": 318,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "x": 0,
+        "y": 440,
+        "w": 24,
+        "h": 14
+      },
+      "datasource": null,
+      "targets": [],
+      "fieldConfig": {
+        "overrides": [],
+        "defaults": {}
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source\n\nGitHub REST API — Pull Requests endpoint.\n\n### Database Table(s)\n\n`pull_requests`\n\n### How It's Calculated\n\n25 most recently merged PRs within the selected time range where `merged_by->>'login' = user`. **Author Login** shows the PR opener, and **Author Type** classifies that login as Copilot, Bot, or Human. Review Time = `merged_at - created_at` in hours, colour-coded blue (<24h) / yellow (24-72h) / red (>72h).\n\n### SQL Query\n\n```sql\nSELECT\n  pr.number AS \"PR #\",\n  pr.title AS \"Title\",\n  pr.user->>'login' AS \"Author Login\",\n  CASE\n    WHEN pr.user->>'login' = 'Copilot' THEN 'Copilot'\n    WHEN pr.user->>'login' LIKE '%[bot]' THEN 'Bot'\n    ELSE 'Human'\n  END AS \"Author Type\",\n  ROUND((EXTRACT(EPOCH FROM (pr.merged_at - pr.created_at)) / 3600.0)::numeric, 1) AS \"Review Time (hrs)\",\n  pr.created_at AS \"Opened\",\n  pr.merged_at AS \"Merged\"\nFROM pull_requests pr\nWHERE pr.merged_by->>'login' = '${user_login}'\n  AND pr.merged_at IS NOT NULL\n  AND pr.merged_at BETWEEN $__timeFrom() AND $__timeTo()\nORDER BY pr.merged_at DESC\nLIMIT 25\n```"
+      }
+    },
+    {
+      "id": 320,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 214,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 212,
+      "type": "row",
+      "title": "Lines Deleted & Net Lines Changed - Learning Guide",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 218,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 311,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "x": 0,
+        "y": 223,
+        "w": 24,
+        "h": 14
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### GitHub API Source [docs](https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10)\n\n`GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest` -> `loc_deleted_sum`, `loc_added_sum`\n\n### Database Table(s)\n\n`copilot_user_daily`\n\n### How It's Calculated\n\n**Lines Deleted (28d)** -> `SUM(loc_deleted_sum)`. Lines removed from the editor by Copilot, primarily through agent mode and edit mode direct file writes. Does not include lines the developer manually deleted.\n\n**Net Lines Changed (28d)** -> `SUM(loc_added_sum) - SUM(loc_deleted_sum)`. Positive = Copilot net-contributed new code. Near-zero or negative = Copilot is doing significant cleanup or refactoring.\n\nAlso see the **Daily Activity Trend** chart above. It includes a red dashed series for Lines Deleted.\n\n### SQL Query\n\n```sql\nSELECT SUM(loc_deleted_sum) AS \"Lines Deleted (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n\nSELECT SUM(loc_added_sum) - COALESCE(SUM(loc_deleted_sum), 0) AS \"Net Lines Changed (28d)\"\nFROM copilot_user_daily\nWHERE user_login = '${user_login}'\n  AND day BETWEEN $__timeFrom()::date AND $__timeTo()::date\n```"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      }
+    },
+    {
+      "id": 328,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 422,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    }
+  ],
+  "links": []
+}

--- a/v3/enterprise-dashboard-raw.json
+++ b/v3/enterprise-dashboard-raw.json
@@ -1,0 +1,1 @@
+{"message":"Dashboard not found","traceID":""}

--- a/v3/enterprise-dashboard.json
+++ b/v3/enterprise-dashboard.json
@@ -1,0 +1,520 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Welcome page ΓÇö dashboard index, architecture overview, schema drift status, and data sync controls.",
+  "id": 6,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "format": "table",
+          "rawSql": "SELECT COALESCE('Live: ' || (SELECT value FROM app_config WHERE key = 'org') || '/' || (SELECT value FROM app_config WHERE key = 'repo'), 'Not yet synced') AS \"Data Source\"",
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "type": "stat"
+    },
+    {
+      "gridPos": {
+        "h": 20,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 1,
+      "options": {
+        "content": "## ≡ƒôï Dashboard Index\n\n| # | Dashboard | Purpose | Tags |\n|---|---|---|---|\n| 1 | [≡ƒÜÇ Deployment Frequency](/d/edu-deployment-frequency) | How often code ships to production | DORA, Throughput |\n| 2 | [ΓÅ▒∩╕Å Lead Time for Changes](/d/edu-lead-time) | Time from first commit to production deployment | DORA, Throughput |\n| 3 | [≡ƒöÑ Change Failure Rate](/d/edu-change-failure-rate) | % of deployments that cause an incident | DORA, Stability |\n| 4 | [≡ƒÅÑ Mean Time to Recovery](/d/edu-mean-time-to-recovery) | Time to resolve an incident after it opens | DORA, Stability |\n| 5 | [≡ƒñû Copilot Adoption](/d/edu-copilot-adoption) | Active seats, acceptance rate, usage by editor | Copilot |\n| 6 | [≡ƒÆ╗ Copilot Code Impact](/d/edu-copilot-code-impact) | Lines suggested vs accepted, LoC trends | Copilot |\n| 7 | [≡ƒö¼ DORA ├ù Copilot](/d/edu-dora-vs-copilot) | Deployment freq & lead time split by Copilot users vs non-users | DORA, Copilot |\n| 8 | [≡ƒæñ Per-User Copilot Metrics](/d/edu-per-user-copilot) | Acceptance rate and activity per developer | Copilot |\n\n---\n\n## ≡ƒÅù∩╕Å Why ELT ΓÇö not ETL\n\nMost production dashboards use **ETL** (Extract ΓåÆ **Transform** ΓåÆ Load): data is reshaped by application code before it ever reaches the database. That keeps queries simple, but it hides what the underlying API actually returns ΓÇö intermediate column names, flattened structures, and computed fields make it hard to understand what you're really measuring or to adapt the pipeline to a new org.\n\nThis tool is built for **learning**, not production hardening. It uses **ELT** (Extract ΓåÆ Load ΓåÆ **Transform**):\n\n| Step | Where it happens | What it means |\n|---|---|---|\n| **Extract** | `src/github/*.ts` | Fetch raw JSON from the GitHub API via Octokit |\n| **Load** | PostgreSQL | Store fields verbatim ΓÇö column names match the API field names exactly |\n| **Transform** | Grafana SQL panels | All aggregations, joins, and calculations live here, in plain SQL |\n\nBecause the schema mirrors the API, you can read a dashboard SQL panel and trace every field back to the GitHub documentation. There are no hidden mappings or invented column names.\n\n```\nGitHub API  ΓåÆ  Octokit SDK (TypeScript)  ΓåÆ  PostgreSQL  ΓåÆ  Grafana SQL\n               src/github/*.ts               db/schema.sql   dashboards/*.json\n```\n\n**Auto-migration** ΓÇö when GitHub adds a new field, the next sync detects it and runs `ALTER TABLE ADD COLUMN` automatically. The _Schema Drift_ section below tracks what has been added.\n\n**Data refresh** ΓÇö click **Refresh Data Now** to pull the latest 28-day rolling window from GitHub.\n\n## ΓÜÖ∩╕Å Environment\n\n| Variable | Purpose |\n|---|---|\n| `GITHUB_TOKEN` | Classic PAT ΓÇö needs `repo`, `read:org`, `admin:org` scopes |\n| `GITHUB_ENTERPRISE` | Enterprise slug (e.g. `Octodemo`) |\n| `GITHUB_ORG` | Organisation name |\n| `GITHUB_REPO` | Repository name |",
+        "mode": "markdown"
+      },
+      "title": "",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 60,
+      "panels": [],
+      "title": "Data Sync",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 61,
+      "options": {
+        "content": "<p style=\"color:#aaa;font-size:13px;margin:6px 12px\">\n<strong style=\"color:#ddd\">Why is a sync needed?</strong>\nData is pulled from the GitHub API in a rolling 28-day window and stored locally in PostgreSQL. It does <em>not</em> update automatically.\nClick <strong>Refresh Data Now</strong> to fetch the latest PRs, deployments, workflow runs, issues, and Copilot metrics (~15ΓÇô30 s).\nThe sync history table below shows recent jobs, their status, and how many records were written.\n</p>",
+        "mode": "html"
+      },
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "FAILED": {
+                  "color": "red",
+                  "index": 1
+                },
+                "RUNNING": {
+                  "color": "blue",
+                  "index": 2
+                },
+                "SUCCESS": {
+                  "color": "semi-dark-green",
+                  "index": 0
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "format": "table",
+          "rawSql": "SELECT UPPER(status) AS \"Last Sync Status\" FROM sync_jobs ORDER BY started_at DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Sync Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "format": "table",
+          "rawSql": "SELECT COALESCE((SELECT SUM(v::int) FROM jsonb_each_text(records_synced) x(k,v)), 0)::bigint AS \"Records Synced\" FROM sync_jobs ORDER BY started_at DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Records Synced (last run)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 100,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:16px\"><button onclick=\"this.disabled=true;this.textContent='RefreshingΓÇª (~15s)';fetch('http://localhost:3005/sync',{method:'POST'}).then(()=>location.reload()).catch(e=>{this.disabled=false;this.textContent='≡ƒöä Refresh Data Now';alert('Sync failed: '+e)})\" style=\"background:#0077cc;color:white;padding:10px 24px;border-radius:4px;cursor:pointer;font-weight:bold;border:none;font-size:14px\">≡ƒöä Refresh Data Now</button><p style=\"color:#888;font-size:12px;margin-top:8px\">Calls POST /sync ┬╖ sync server on localhost:3005</p></div>",
+        "mode": "html"
+      },
+      "targets": [],
+      "title": "Refresh Data",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "format": "table",
+          "rawSql": "SELECT TO_CHAR(started_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI') || ' UTC' AS \"Last Sync\" FROM sync_jobs ORDER BY started_at DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Sync Time",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 102,
+      "options": {
+        "frameIndex": 0,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "format": "table",
+          "rawSql": "SELECT id AS \"Job\", status AS \"Status\", TO_CHAR(started_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI') AS \"Started\", COALESCE((SELECT SUM(v::int) FROM jsonb_each_text(records_synced) x(k,v)), 0)::bigint AS \"Records\" FROM sync_jobs ORDER BY id DESC LIMIT 10",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent Sync History",
+      "transformations": [],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 50,
+      "panels": [],
+      "title": "Schema Drift",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 51,
+      "options": {
+        "content": "<p style=\"color:#aaa;font-size:13px;margin:6px 12px\">\n<strong style=\"color:#ddd\">Why does schema drift happen?</strong>\nThe GitHub API occasionally adds new fields to its responses. On each sync, this app compares incoming API fields against the current database columns.\nIf a new field is found, it automatically runs <code>ALTER TABLE ADD COLUMN</code> ΓÇö the live database is updated immediately, no restart needed.\n</p>\n<p style=\"color:#aaa;font-size:13px;margin:6px 12px\">\n<strong style=\"color:#ddd\">Live DB vs schema.sql</strong>\nThe automatic migration keeps the <em>live database</em> current, but it does <strong style=\"color:#e88\">not</strong> update the checked-in <code>v3/src/db/schema.sql</code> file.\nThe counter below shows how many columns have been auto-added to the live database but are still missing from that file.\nUntil schema.sql is updated, a fresh database rebuild will be missing those columns.\n</p>\n<p style=\"color:#aaa;font-size:13px;margin:6px 12px\">\n<strong style=\"color:#ddd\">How to update schema.sql</strong>\n</p>\n<ol style=\"color:#aaa;font-size:13px;margin:2px 12px 6px 28px\">\n<li>Check the <em>Drift History</em> table below to identify which tables and fields were auto-added.</li>\n<li>Open <code>v3/src/db/schema.sql</code> and add each missing column to the matching <code>CREATE TABLE</code> block using the type shown in the drift log.</li>\n<li>Commit: <code>git add v3/src/db/schema.sql &amp;&amp; git commit -m \"chore: sync schema.sql with auto-migrated columns\"</code></li>\n<li>No database rebuild needed ΓÇö the columns already exist in the live DB.</li>\n</ol>",
+        "mode": "html"
+      },
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "semi-dark-green",
+                  "index": 0,
+                  "text": "Γ£ô Up to date"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "ΓÇö",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "format": "table",
+          "rawSql": "WITH latest AS (\n  SELECT schema_drift\n  FROM sync_jobs\n  WHERE status = 'success'\n  ORDER BY id DESC LIMIT 1\n),\nall_drift AS (\n  SELECT DISTINCT\n    (entry->>'table') || '.' || (col->>'field') AS col_key\n  FROM latest,\n    jsonb_array_elements(latest.schema_drift) AS entry,\n    jsonb_array_elements(entry->'auto_applied') AS col\n  WHERE latest.schema_drift IS NOT NULL AND latest.schema_drift != '[]'::jsonb\n)\nSELECT COALESCE(COUNT(*)::int, 0) AS \"Columns not in schema.sql\" FROM all_drift",
+          "refId": "A"
+        }
+      ],
+      "title": "Columns not in schema.sql",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 52,
+      "options": {
+        "frameIndex": 0,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "PostgreSQL"
+          },
+          "format": "table",
+          "rawSql": "-- One row per drifted table per sync job; 'None' for clean syncs\nSELECT\n  j.id                                                   AS \"Job\",\n  TO_CHAR(j.started_at AT TIME ZONE 'UTC',\n          'YYYY-MM-DD HH24:MI')                          AS \"Synced At\",\n  entry->>'table'                                        AS \"Table\",\n  (\n    SELECT string_agg(col->>'field', ', '\n           ORDER BY col->>'field')\n    FROM jsonb_array_elements(entry->'auto_applied') col\n  )                                                      AS \"Columns Added\"\nFROM sync_jobs j,\n     jsonb_array_elements(j.schema_drift) entry\nWHERE j.schema_drift IS NOT NULL\n  AND j.schema_drift <> '[]'::jsonb\n  AND jsonb_array_length(\n        COALESCE(entry->'auto_applied', '[]'::jsonb)) > 0\n\nUNION ALL\n\nSELECT\n  j.id                                                   AS \"Job\",\n  TO_CHAR(j.started_at AT TIME ZONE 'UTC',\n          'YYYY-MM-DD HH24:MI')                          AS \"Synced At\",\n  '(none)'                                               AS \"Table\",\n  'None'                                                 AS \"Columns Added\"\nFROM sync_jobs j\nWHERE j.schema_drift IS NULL\n   OR j.schema_drift = '[]'::jsonb\n   OR NOT EXISTS (\n        SELECT 1\n        FROM jsonb_array_elements(j.schema_drift) e\n        WHERE jsonb_array_length(\n                COALESCE(e->'auto_applied', '[]'::jsonb)) > 0\n      )\n\nORDER BY 1 DESC, 3\nLIMIT 30",
+          "refId": "A"
+        }
+      ],
+      "title": "Drift History (last 10 syncs)",
+      "transformations": [],
+      "type": "table"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 36,
+  "tags": [
+    "overview",
+    "edu"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-28d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "title": "≡ƒôè Engineering Overview [v3]",
+  "uid": "v3-overview",
+  "version": 49
+}

--- a/v3/grafana/dashboards/10-enterprise-copilot-leading.json
+++ b/v3/grafana/dashboards/10-enterprise-copilot-leading.json
@@ -1,9 +1,9 @@
 {
   "uid": "edu-enterprise-leading",
   "title": "🏢 Enterprise Copilot Leading Indicators [Edu]",
-  "description": "Enterprise-level Copilot leading indicators — PR throughput, adoption metrics, and code volume — aggregated across all organizations.",
+  "description": "Enterprise-level Copilot leading indicators focused on API-only fields (pull-request activity and Copilot code review engagement) that are NOT shown in the built-in Copilot Usage dashboard at /enterprises/<enterprise>/insights/copilot/usage.",
   "schemaVersion": 36,
-  "version": 1,
+  "version": 2,
   "refresh": "5m",
   "time": {
     "from": "now-28d",
@@ -18,36 +18,60 @@
   },
   "panels": [
     {
-      "id": 1,
-      "type": "stat",
-      "title": "PRs Created (28 days)",
+      "id": 100,
+      "type": "text",
+      "title": "",
+      "transparent": true,
       "gridPos": {
         "x": 0,
         "y": 0,
-        "w": 6,
-        "h": 4
+        "w": 24,
+        "h": 14
       },
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "PostgreSQL"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "rawSql": "SELECT SUM((pull_requests->>'total_created')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)",
-          "format": "table"
-        }
-      ]
+      "options": {
+        "mode": "markdown",
+        "content": "# 🏢 Enterprise Copilot Leading Indicators\n\n## Why leading indicators?\n\nThe [GitHub Engineering System Success Playbook (ESSP)](https://github.com/resources/insights/engineering-system-success-playbook) recommends balancing **leading** and **lagging** indicators — and pairing each lagging metric with a companion leading metric — to drive engineering system improvements ([ESSP e-book, p. *Leading versus lagging metrics*](https://assets.ctfassets.net/wfutmusr1t3h/59IWCIRvx0KfHbh6B7bv62/d9f55b94ab43fe91e9ed183d73882954/2025-05-28-GitHub-ESSP-Ebook-EZ-Version012.pdf)):\n\n- **Lagging indicators** — outcomes measured *after* work is completed (e.g., deployment frequency, mean time to recovery). Important for long-term results, but gains take time to be realized.\n- **Leading indicators** — signals close to the source of friction that *predict* downstream outcomes. For example, improvements in code-review time alongside developer confidence in code review can signal future improvements in deployment speed and quality.\n\n> *\"To truly measure progress, it's important to complement each of the 12 engineering success metrics with leading indicators that reflect the team's day-to-day coding activities and the points of friction to be addressed, allowing for proactive adjustments.\"* — GitHub ESSP\n\nThe SPACE **Communication & Collaboration** domain (code review, PR throughput, review engagement) is a key source of leading indicators when those are your friction points.\n\n## What this dashboard shows\n\nThis dashboard surfaces **enterprise-scoped, API-only Copilot metrics** that act as leading indicators for the lagging DORA metrics on the other dashboards in this stack. They are intentionally **complementary to** — not duplicative of — the built-in Copilot Usage dashboard at `https://github.com/enterprises/<enterprise>/insights/copilot/usage?period=28d` (which already covers DAU/WAU/MAU, lines added/deleted, completions suggested/accepted, and language/IDE breakdowns).\n\nFields are sourced from [Copilot usage metrics → Pull request activity fields (API only)](https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#pull-request-activity-fields-api-only) plus the API-only Copilot code-review engagement fields. Each comparison section shows the enterprise-wide total, the Copilot-attributed count, and a percentage — so you can see both *volume* and *share* at a glance, with a daily time-series to reveal trends the 28-day rollups can hide.\n\n| Leading indicator (this dashboard) | Lagging metric it informs |\n|---|---|\n| PRs created / created by Copilot, daily trend | Deployment frequency, change volume |\n| PRs reviewed / reviewed by Copilot | Lead time for changes, review throughput |\n| Active vs passive code-review engagement | Review quality, developer confidence |\n| Median minutes to merge — all vs Copilot-authored | Lead time for changes |\n| Copilot suggestion apply rate | Review effectiveness, change failure rate |"
+      }
     },
     {
-      "id": 2,
-      "type": "stat",
-      "title": "Monthly Active Users",
+      "id": 300,
+      "type": "text",
+      "title": "",
+      "transparent": true,
       "gridPos": {
-        "x": 6,
-        "y": 0,
-        "w": 6,
+        "x": 0,
+        "y": 14,
+        "w": 24,
         "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 110,
+      "type": "row",
+      "collapsed": false,
+      "title": "Pull Request Creation — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 111,
+      "type": "stat",
+      "title": "PRs Created (28d)",
+      "description": "pull_requests.total_created summed over the last 28 days.",
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 8,
+        "h": 5
       },
       "datasource": {
         "type": "grafana-postgresql-datasource",
@@ -56,20 +80,1040 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT MAX(monthly_active_users) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)",
-          "format": "table"
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_created')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
         }
       ]
     },
     {
-      "id": 3,
+      "id": 112,
       "type": "stat",
-      "title": "Lines of Code Suggested",
+      "title": "PRs Created by Copilot (28d)",
+      "description": "pull_requests.total_created_by_copilot summed over the last 28 days.",
+      "gridPos": {
+        "x": 8,
+        "y": 19,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_created_by_copilot')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 113,
+      "type": "gauge",
+      "title": "% Created by Copilot",
+      "description": "Share of PRs created by Copilot vs total PRs created in the last 28 days.",
+      "gridPos": {
+        "x": 16,
+        "y": 19,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_created_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_created')::int), 0), 1) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 114,
+      "type": "timeseries",
+      "title": "PRs Created — Daily (Total vs Copilot)",
+      "description": "Daily trend of total PRs created vs PRs created by Copilot. Reveals adoption ramp over time.",
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_created')::int AS \"Total Created\", (pull_requests->>'total_created_by_copilot')::int AS \"Created by Copilot\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 115,
+      "type": "text",
+      "title": "Pull Request Creation — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 24,
+        "h": 27
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_created` and `pull_requests.total_created_by_copilot` from the enterprise `Copilot usage metrics` API (28-day report).\n\n**Calculation:**\n- Stat panels sum each field across the last 28 days.\n- Percent gauge: `SUM(total_created_by_copilot) / NULLIF(SUM(total_created), 0) * 100`.\n\n**SQL pattern:**\n```sql\nSELECT (pull_requests->>'total_created')::int FROM copilot_enterprise_daily\n```\n\n**Why time-series:** The 28-day total hides whether Copilot-authored PR creation is *trending up* (adoption working) or *flat* (rollout stalled). The daily trend is the primary signal for measuring Copilot Coding Agent adoption.\n\n---\n\n### Underlying SQL\n\n**PRs Created (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_created')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**PRs Created by Copilot (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_created_by_copilot')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**% Created by Copilot**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_created_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_created')::int), 0), 1) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**PRs Created — Daily (Total vs Copilot)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_created')::int AS \"Total Created\", (pull_requests->>'total_created_by_copilot')::int AS \"Created by Copilot\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 301,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 59,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 120,
+      "type": "row",
+      "collapsed": false,
+      "title": "Pull Request Review — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 60,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 121,
+      "type": "stat",
+      "title": "PRs Reviewed (28d)",
+      "description": "pull_requests.total_reviewed summed over the last 28 days.",
+      "gridPos": {
+        "x": 0,
+        "y": 61,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_reviewed')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 122,
+      "type": "stat",
+      "title": "PRs Reviewed by Copilot (28d)",
+      "description": "pull_requests.total_reviewed_by_copilot summed over the last 28 days.",
+      "gridPos": {
+        "x": 8,
+        "y": 61,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_reviewed_by_copilot')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 123,
+      "type": "gauge",
+      "title": "% Reviewed by Copilot",
+      "description": "Share of PR review days where Copilot reviewed (vs total review days). Note: a PR may be reviewed on multiple days.",
+      "gridPos": {
+        "x": 16,
+        "y": 61,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_reviewed_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_reviewed')::int), 0), 1) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 124,
+      "type": "timeseries",
+      "title": "PRs Reviewed — Daily (Total vs Copilot)",
+      "description": "Daily trend of total PRs reviewed vs PRs reviewed by Copilot.",
+      "gridPos": {
+        "x": 0,
+        "y": 66,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_reviewed')::int AS \"Total Reviewed\", (pull_requests->>'total_reviewed_by_copilot')::int AS \"Reviewed by Copilot\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 125,
+      "type": "text",
+      "title": "Pull Request Review — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 74,
+        "w": 24,
+        "h": 25
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_reviewed` and `pull_requests.total_reviewed_by_copilot`.\n\n**Important:** A PR is counted on **every day** it receives a review action (so totals can exceed unique-PR counts). Within a single day each PR is counted at most once.\n\n**Calculation:**\n- Stat panels sum each field across the last 28 days.\n- Percent gauge: `SUM(total_reviewed_by_copilot) / NULLIF(SUM(total_reviewed), 0) * 100`.\n\n**Why time-series:** Reveals whether Copilot review usage is sustained or sporadic. A flat-line at zero indicates Copilot code review is not enabled or not being requested.\n\n---\n\n### Underlying SQL\n\n**PRs Reviewed (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_reviewed')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**PRs Reviewed by Copilot (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_reviewed_by_copilot')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**% Reviewed by Copilot**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_reviewed_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_reviewed')::int), 0), 1) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**PRs Reviewed — Daily (Total vs Copilot)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_reviewed')::int AS \"Total Reviewed\", (pull_requests->>'total_reviewed_by_copilot')::int AS \"Reviewed by Copilot\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 302,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 99,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 130,
+      "type": "row",
+      "collapsed": false,
+      "title": "Copilot Code Review Engagement (Active vs Passive) — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 100,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 131,
+      "type": "stat",
+      "title": "Monthly Active Code Review Users",
+      "description": "monthly_active_copilot_code_review_users — users who manually requested a Copilot review or applied a Copilot review suggestion in the 28-day window.",
+      "gridPos": {
+        "x": 0,
+        "y": 101,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT MAX(monthly_active_copilot_code_review_users) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 132,
+      "type": "stat",
+      "title": "Monthly Passive Code Review Users",
+      "description": "monthly_passive_copilot_code_review_users — users who had Copilot auto-assigned to review their PR but did not actively engage.",
+      "gridPos": {
+        "x": 8,
+        "y": 101,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT MAX(monthly_passive_copilot_code_review_users) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 133,
+      "type": "gauge",
+      "title": "Active Engagement Rate",
+      "description": "active / (active + passive) — high values mean developers actively use Copilot reviews; low values mean Copilot is auto-assigning but being ignored.",
+      "gridPos": {
+        "x": 16,
+        "y": 101,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 25
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 75
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * MAX(monthly_active_copilot_code_review_users) / NULLIF(MAX(monthly_active_copilot_code_review_users) + MAX(monthly_passive_copilot_code_review_users), 0), 1) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 134,
+      "type": "timeseries",
+      "title": "Daily Code Review Users — Active vs Passive",
+      "description": "Daily trend of active vs passive Copilot code review users.",
+      "gridPos": {
+        "x": 0,
+        "y": 106,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, daily_active_copilot_code_review_users AS \"Active\", daily_passive_copilot_code_review_users AS \"Passive\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 135,
+      "type": "text",
+      "title": "Copilot Code Review Engagement — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 114,
+        "w": 24,
+        "h": 24
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API fields (API only — not in built-in dashboard):**\n- `daily_active_copilot_code_review_users` / `monthly_active_copilot_code_review_users` — actively engaged (manually requested a review or applied a review suggestion).\n- `daily_passive_copilot_code_review_users` / `monthly_passive_copilot_code_review_users` — auto-assigned but did not engage.\n\n**Active Engagement Rate** = `active / (active + passive)`. A high passive count with low active rate is a leading indicator that Copilot reviews are being ignored — a coaching/enablement opportunity.\n\n**Why time-series:** Shows whether engagement is improving as teams adopt the feature, or whether passive auto-assignments are growing without corresponding active use.\n\n---\n\n### Underlying SQL\n\n**Monthly Active Code Review Users**\n\n```sql\nSELECT MAX(monthly_active_copilot_code_review_users) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**Monthly Passive Code Review Users**\n\n```sql\nSELECT MAX(monthly_passive_copilot_code_review_users) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**Active Engagement Rate**\n\n```sql\nSELECT ROUND(100.0 * MAX(monthly_active_copilot_code_review_users) / NULLIF(MAX(monthly_active_copilot_code_review_users) + MAX(monthly_passive_copilot_code_review_users), 0), 1) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**Daily Code Review Users — Active vs Passive**\n\n```sql\nSELECT day AS time, daily_active_copilot_code_review_users AS \"Active\", daily_passive_copilot_code_review_users AS \"Passive\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 303,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 138,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 140,
+      "type": "row",
+      "collapsed": false,
+      "title": "Pull Request Merge & Lead Time — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 139,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 141,
+      "type": "stat",
+      "title": "PRs Merged (28d)",
+      "description": "pull_requests.total_merged summed over the last 28 days.",
+      "gridPos": {
+        "x": 0,
+        "y": 140,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_merged')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 142,
+      "type": "stat",
+      "title": "PRs Merged that Copilot Created (28d)",
+      "description": "pull_requests.total_merged_created_by_copilot summed over the last 28 days.",
+      "gridPos": {
+        "x": 8,
+        "y": 140,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_merged_created_by_copilot')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 143,
+      "type": "gauge",
+      "title": "% Merged that Copilot Created",
+      "description": "Share of merged PRs that were created by Copilot.",
+      "gridPos": {
+        "x": 16,
+        "y": 140,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_merged_created_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_merged')::int), 0), 1) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 144,
+      "type": "timeseries",
+      "title": "PRs Merged — Daily (Total vs Copilot-Authored)",
+      "description": "Daily trend of total merged PRs vs Copilot-authored merged PRs.",
+      "gridPos": {
+        "x": 0,
+        "y": 145,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_merged')::int AS \"Total Merged\", (pull_requests->>'total_merged_created_by_copilot')::int AS \"Copilot-Authored Merged\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 145,
+      "type": "timeseries",
+      "title": "Median Minutes to Merge — All vs Copilot-Authored",
+      "description": "Daily median minutes from PR creation to merge — overall vs Copilot-authored. Reveals lead-time drift between human-authored and Copilot-authored PRs.",
+      "gridPos": {
+        "x": 0,
+        "y": 153,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'median_minutes_to_merge')::numeric AS \"All PRs\", (pull_requests->>'median_minutes_to_merge_copilot_authored')::numeric AS \"Copilot-Authored\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 146,
+      "type": "text",
+      "title": "Pull Request Merge & Lead Time — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 161,
+        "w": 24,
+        "h": 28
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_merged`, `pull_requests.total_merged_created_by_copilot`, `pull_requests.median_minutes_to_merge`, `pull_requests.median_minutes_to_merge_copilot_authored`.\n\n**Calculation:** Each PR is counted on the day it was merged (one-time event). Median values are *daily medians* reported by GitHub — do not average them across days; chart them as a trend.\n\n**Why two time-series:** The *count* trend shows merge throughput; the *median minutes to merge* trend reveals whether Copilot-authored PRs are getting through review faster or slower than human-authored ones over time. A widening gap is a leading signal worth investigating.\n\n---\n\n### Underlying SQL\n\n**PRs Merged (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_merged')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**PRs Merged that Copilot Created (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_merged_created_by_copilot')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**% Merged that Copilot Created**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_merged_created_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_merged')::int), 0), 1) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**PRs Merged — Daily (Total vs Copilot-Authored)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_merged')::int AS \"Total Merged\", (pull_requests->>'total_merged_created_by_copilot')::int AS \"Copilot-Authored Merged\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```\n\n**Median Minutes to Merge — All vs Copilot-Authored**\n\n```sql\nSELECT day AS time, (pull_requests->>'median_minutes_to_merge')::numeric AS \"All PRs\", (pull_requests->>'median_minutes_to_merge_copilot_authored')::numeric AS \"Copilot-Authored\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 304,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 189,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 150,
+      "type": "row",
+      "collapsed": false,
+      "title": "PR Review Suggestions — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 190,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 151,
+      "type": "stat",
+      "title": "Total PR Review Suggestions (28d)",
+      "description": "pull_requests.total_suggestions — review suggestions generated by any author.",
+      "gridPos": {
+        "x": 0,
+        "y": 191,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_suggestions')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 152,
+      "type": "stat",
+      "title": "Copilot PR Suggestions (28d)",
+      "description": "pull_requests.total_copilot_suggestions — review suggestions generated by Copilot.",
+      "gridPos": {
+        "x": 8,
+        "y": 191,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_copilot_suggestions')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 153,
+      "type": "gauge",
+      "title": "% Suggestions from Copilot",
+      "description": "Share of PR review suggestions generated by Copilot.",
+      "gridPos": {
+        "x": 16,
+        "y": 191,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_copilot_suggestions')::int) / NULLIF(SUM((pull_requests->>'total_suggestions')::int), 0), 1) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 154,
+      "type": "timeseries",
+      "title": "PR Review Suggestions — Daily (Total vs Copilot)",
+      "description": "Daily trend of all review suggestions vs Copilot-generated suggestions.",
+      "gridPos": {
+        "x": 0,
+        "y": 196,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_suggestions')::int AS \"Total\", (pull_requests->>'total_copilot_suggestions')::int AS \"Copilot\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 155,
+      "type": "text",
+      "title": "PR Review Suggestions — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 204,
+        "w": 24,
+        "h": 23
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_suggestions` (any author) and `pull_requests.total_copilot_suggestions` (Copilot only).\n\n**Calculation:** Sums of suggestions generated each day; the percent gauge is `copilot / total`.\n\n**Pair this with the Applied Suggestions section below** — high suggestion volume with a low apply rate suggests the suggestions are noisy or low-quality. High volume + high apply rate is the signal of healthy Copilot review adoption.\n\n---\n\n### Underlying SQL\n\n**Total PR Review Suggestions (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_suggestions')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**Copilot PR Suggestions (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_copilot_suggestions')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**% Suggestions from Copilot**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_copilot_suggestions')::int) / NULLIF(SUM((pull_requests->>'total_suggestions')::int), 0), 1) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**PR Review Suggestions — Daily (Total vs Copilot)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_suggestions')::int AS \"Total\", (pull_requests->>'total_copilot_suggestions')::int AS \"Copilot\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 305,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 227,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 160,
+      "type": "row",
+      "collapsed": false,
+      "title": "Applied PR Suggestions (Apply Rate) — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 228,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 161,
+      "type": "stat",
+      "title": "Applied Suggestions — All (28d)",
+      "description": "pull_requests.total_applied_suggestions — review suggestions applied (any author).",
+      "gridPos": {
+        "x": 0,
+        "y": 229,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_applied_suggestions')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 162,
+      "type": "stat",
+      "title": "Applied Copilot Suggestions (28d)",
+      "description": "pull_requests.total_copilot_applied_suggestions — Copilot-generated suggestions that were applied.",
+      "gridPos": {
+        "x": 8,
+        "y": 229,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_copilot_applied_suggestions')::int) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 163,
+      "type": "gauge",
+      "title": "Copilot Suggestion Apply Rate",
+      "description": "applied_copilot / generated_copilot — high values mean reviewers find Copilot's suggestions useful and accept them.",
+      "gridPos": {
+        "x": 16,
+        "y": 229,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 40
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_copilot_applied_suggestions')::int) / NULLIF(SUM((pull_requests->>'total_copilot_suggestions')::int), 0), 1) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)"
+        }
+      ]
+    },
+    {
+      "id": 164,
+      "type": "timeseries",
+      "title": "Copilot Suggestions — Daily (Generated vs Applied)",
+      "description": "Daily trend of Copilot suggestions generated vs applied. The gap reveals quality and engagement.",
+      "gridPos": {
+        "x": 0,
+        "y": 234,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_copilot_suggestions')::int AS \"Generated\", (pull_requests->>'total_copilot_applied_suggestions')::int AS \"Applied\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 165,
+      "type": "text",
+      "title": "Applied PR Suggestions — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 242,
+        "w": 24,
+        "h": 23
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_applied_suggestions` (any author) and `pull_requests.total_copilot_applied_suggestions` (Copilot only).\n\n**Apply Rate:** `total_copilot_applied_suggestions / NULLIF(total_copilot_suggestions, 0) * 100` — the most actionable single number on this dashboard. A low rate (< 10%) suggests Copilot's review feedback is being dismissed; investigate signal quality, model selection, or reviewer workflow.\n\n**Why time-series:** Generated-vs-applied gap over time shows whether reviewer trust in Copilot suggestions is growing, shrinking, or stable.\n\n---\n\n### Underlying SQL\n\n**Applied Suggestions — All (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_applied_suggestions')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**Applied Copilot Suggestions (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_copilot_applied_suggestions')::int) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**Copilot Suggestion Apply Rate**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_copilot_applied_suggestions')::int) / NULLIF(SUM((pull_requests->>'total_copilot_suggestions')::int), 0), 1) AS value\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\n```\n\n**Copilot Suggestions — Daily (Generated vs Applied)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_copilot_suggestions')::int AS \"Generated\", (pull_requests->>'total_copilot_applied_suggestions')::int AS \"Applied\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 306,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 265,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 170,
+      "type": "row",
+      "collapsed": false,
+      "title": "API-Only Adoption Signals (CLI, Suggestions, Interactions) — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 266,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 171,
+      "type": "timeseries",
+      "title": "Daily Active CLI Users",
+      "description": "daily_active_cli_users — unique users who used Copilot via the CLI on each day. CLI usage is independent of IDE active-user counts and is API-only.",
+      "gridPos": {
+        "x": 0,
+        "y": 267,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, daily_active_cli_users AS \"Daily Active CLI Users\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 172,
+      "type": "timeseries",
+      "title": "Total User-Initiated Interactions",
+      "description": "user_initiated_interaction_count — daily count of explicit prompts sent to Copilot. Excludes UI events like opening the chat panel or switching modes. API-only.",
       "gridPos": {
         "x": 12,
-        "y": 0,
-        "w": 6,
-        "h": 4
+        "y": 267,
+        "w": 12,
+        "h": 8
       },
       "datasource": {
         "type": "grafana-postgresql-datasource",
@@ -78,20 +1122,21 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT SUM(loc_suggested_to_add_sum) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)",
-          "format": "table"
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, user_initiated_interaction_count AS \"User-Initiated Interactions\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
         }
       ]
     },
     {
-      "id": 4,
-      "type": "stat",
-      "title": "Lines of Code Added",
+      "id": 173,
+      "type": "timeseries",
+      "title": "Lines of Code Suggested — Add vs Delete",
+      "description": "loc_suggested_to_add_sum and loc_suggested_to_delete_sum — what Copilot proposed vs what was kept (compare with the LoC accepted metrics on the built-in dashboard).",
       "gridPos": {
-        "x": 18,
-        "y": 0,
-        "w": 6,
-        "h": 4
+        "x": 0,
+        "y": 275,
+        "w": 24,
+        "h": 8
       },
       "datasource": {
         "type": "grafana-postgresql-datasource",
@@ -100,10 +1145,25 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT SUM(loc_added_sum) AS value FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily)",
-          "format": "table"
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, loc_suggested_to_add_sum AS \"Suggested to Add\", loc_suggested_to_delete_sum AS \"Suggested to Delete\" FROM copilot_enterprise_daily WHERE day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_enterprise_daily) ORDER BY day"
         }
       ]
+    },
+    {
+      "id": 174,
+      "type": "text",
+      "title": "API-Only Adoption Signals — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 283,
+        "w": 24,
+        "h": 20
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**Why these are here:** Each of these fields is **API-only** — none appear on the built-in Copilot Usage dashboard at `/orgs/<org>/insights/copilot/usage`.\n\n- `daily_active_cli_users` — CLI surface area is independent of IDE; growth here indicates terminal-driven workflows.\n- `user_initiated_interaction_count` — explicit prompts only. Distinct from `code_generation_activity_count` because one prompt can produce multiple generations.\n- `loc_suggested_to_add_sum` / `loc_suggested_to_delete_sum` — what Copilot *offered*, not what was kept. Compare with `loc_added_sum` / `loc_deleted_sum` on the built-in dashboard to estimate take-up rate.\n\n---\n\n### Underlying SQL\n\n**Daily Active CLI Users**\n\n```sql\nSELECT day AS time, daily_active_cli_users AS \"Daily Active CLI Users\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```\n\n**Total User-Initiated Interactions**\n\n```sql\nSELECT day AS time, user_initiated_interaction_count AS \"User-Initiated Interactions\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```\n\n**Lines of Code Suggested — Add vs Delete**\n\n```sql\nSELECT day AS time, loc_suggested_to_add_sum AS \"Suggested to Add\", loc_suggested_to_delete_sum AS \"Suggested to Delete\"\nFROM copilot_enterprise_daily\nWHERE day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_enterprise_daily)\nORDER BY day\n```"
+      }
     }
   ]
 }

--- a/v3/grafana/dashboards/11-organization-copilot-leading.json
+++ b/v3/grafana/dashboards/11-organization-copilot-leading.json
@@ -1,9 +1,9 @@
 {
   "uid": "edu-organization-leading",
   "title": "🏛️ Organization Copilot Leading Indicators [Edu]",
-  "description": "Organization-level Copilot leading indicators — PR throughput, adoption metrics, and code volume — aggregated at the organization scope.",
+  "description": "Organization-level Copilot leading indicators focused on API-only fields (pull-request activity and Copilot code review engagement) that are NOT shown in the built-in Copilot Usage dashboard at /orgs/<org>/insights/copilot/usage.",
   "schemaVersion": 36,
-  "version": 1,
+  "version": 2,
   "refresh": "5m",
   "time": {
     "from": "now-28d",
@@ -36,36 +36,60 @@
   },
   "panels": [
     {
-      "id": 1,
-      "type": "stat",
-      "title": "PRs Created (28 days)",
+      "id": 100,
+      "type": "text",
+      "title": "",
+      "transparent": true,
       "gridPos": {
         "x": 0,
         "y": 0,
-        "w": 6,
-        "h": 4
+        "w": 24,
+        "h": 14
       },
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "PostgreSQL"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "rawSql": "SELECT SUM((pull_requests->>'total_created')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily)",
-          "format": "table"
-        }
-      ]
+      "options": {
+        "mode": "markdown",
+        "content": "# 🏛️ Organization Copilot Leading Indicators\n\n## Why leading indicators?\n\nThe [GitHub Engineering System Success Playbook (ESSP)](https://github.com/resources/insights/engineering-system-success-playbook) recommends balancing **leading** and **lagging** indicators — and pairing each lagging metric with a companion leading metric — to drive engineering system improvements ([ESSP e-book, p. *Leading versus lagging metrics*](https://assets.ctfassets.net/wfutmusr1t3h/59IWCIRvx0KfHbh6B7bv62/d9f55b94ab43fe91e9ed183d73882954/2025-05-28-GitHub-ESSP-Ebook-EZ-Version012.pdf)):\n\n- **Lagging indicators** — outcomes measured *after* work is completed (e.g., deployment frequency, mean time to recovery). Important for long-term results, but gains take time to be realized.\n- **Leading indicators** — signals close to the source of friction that *predict* downstream outcomes. For example, improvements in code-review time alongside developer confidence in code review can signal future improvements in deployment speed and quality.\n\n> *\"To truly measure progress, it's important to complement each of the 12 engineering success metrics with leading indicators that reflect the team's day-to-day coding activities and the points of friction to be addressed, allowing for proactive adjustments.\"* — GitHub ESSP\n\nThe SPACE **Communication & Collaboration** domain (code review, PR throughput, review engagement) is a key source of leading indicators when those are your friction points.\n\n## What this dashboard shows\n\nThis dashboard surfaces **organization-scoped, API-only Copilot metrics** that act as leading indicators for the lagging DORA metrics on the other dashboards in this stack. They are intentionally **complementary to** — not duplicative of — the built-in Copilot Usage dashboard at `https://github.com/orgs/<org>/insights/copilot/usage?period=28d` (which already covers DAU/WAU/MAU, lines added/deleted, completions suggested/accepted, and language/IDE breakdowns).\n\nFields are sourced from [Copilot usage metrics → Pull request activity fields (API only)](https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#pull-request-activity-fields-api-only) plus the API-only Copilot code-review engagement fields. Each comparison section shows the organization-wide total, the Copilot-attributed count, and a percentage — so you can see both *volume* and *share* at a glance, with a daily time-series to reveal trends the 28-day rollups can hide.\n\n| Leading indicator (this dashboard) | Lagging metric it informs |\n|---|---|\n| PRs created / created by Copilot, daily trend | Deployment frequency, change volume |\n| PRs reviewed / reviewed by Copilot | Lead time for changes, review throughput |\n| Active vs passive code-review engagement | Review quality, developer confidence |\n| Median minutes to merge — all vs Copilot-authored | Lead time for changes |\n| Copilot suggestion apply rate | Review effectiveness, change failure rate |"
+      }
     },
     {
-      "id": 2,
-      "type": "stat",
-      "title": "Monthly Active Users",
+      "id": 300,
+      "type": "text",
+      "title": "",
+      "transparent": true,
       "gridPos": {
-        "x": 6,
-        "y": 0,
-        "w": 6,
+        "x": 0,
+        "y": 14,
+        "w": 24,
         "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 110,
+      "type": "row",
+      "collapsed": false,
+      "title": "Pull Request Creation — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 111,
+      "type": "stat",
+      "title": "PRs Created (28d)",
+      "description": "pull_requests.total_created summed over the last 28 days.",
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 8,
+        "h": 5
       },
       "datasource": {
         "type": "grafana-postgresql-datasource",
@@ -74,20 +98,1040 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT MAX(monthly_active_users) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily)",
-          "format": "table"
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_created')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
         }
       ]
     },
     {
-      "id": 3,
+      "id": 112,
       "type": "stat",
-      "title": "Lines of Code Suggested",
+      "title": "PRs Created by Copilot (28d)",
+      "description": "pull_requests.total_created_by_copilot summed over the last 28 days.",
+      "gridPos": {
+        "x": 8,
+        "y": 19,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_created_by_copilot')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 113,
+      "type": "gauge",
+      "title": "% Created by Copilot",
+      "description": "Share of PRs created by Copilot vs total PRs created in the last 28 days.",
+      "gridPos": {
+        "x": 16,
+        "y": 19,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_created_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_created')::int), 0), 1) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 114,
+      "type": "timeseries",
+      "title": "PRs Created — Daily (Total vs Copilot)",
+      "description": "Daily trend of total PRs created vs PRs created by Copilot. Reveals adoption ramp over time.",
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_created')::int AS \"Total Created\", (pull_requests->>'total_created_by_copilot')::int AS \"Created by Copilot\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 115,
+      "type": "text",
+      "title": "Pull Request Creation — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 24,
+        "h": 29
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_created` and `pull_requests.total_created_by_copilot` from the org `Copilot usage metrics` API (28-day report).\n\n**Calculation:**\n- Stat panels sum each field across the last 28 days.\n- Percent gauge: `SUM(total_created_by_copilot) / NULLIF(SUM(total_created), 0) * 100`.\n\n**SQL pattern:**\n```sql\nSELECT (pull_requests->>'total_created')::int FROM copilot_organization_daily\nWHERE organization_id = '$organization_id'\n```\n\n**Why time-series:** The 28-day total hides whether Copilot-authored PR creation is *trending up* (adoption working) or *flat* (rollout stalled). The daily trend is the primary signal for measuring Copilot Coding Agent adoption.\n\n---\n\n### Underlying SQL\n\n**PRs Created (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_created')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**PRs Created by Copilot (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_created_by_copilot')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**% Created by Copilot**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_created_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_created')::int), 0), 1) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**PRs Created — Daily (Total vs Copilot)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_created')::int AS \"Total Created\", (pull_requests->>'total_created_by_copilot')::int AS \"Created by Copilot\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 301,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 61,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 120,
+      "type": "row",
+      "collapsed": false,
+      "title": "Pull Request Review — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 62,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 121,
+      "type": "stat",
+      "title": "PRs Reviewed (28d)",
+      "description": "pull_requests.total_reviewed summed over the last 28 days.",
+      "gridPos": {
+        "x": 0,
+        "y": 63,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_reviewed')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 122,
+      "type": "stat",
+      "title": "PRs Reviewed by Copilot (28d)",
+      "description": "pull_requests.total_reviewed_by_copilot summed over the last 28 days.",
+      "gridPos": {
+        "x": 8,
+        "y": 63,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_reviewed_by_copilot')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 123,
+      "type": "gauge",
+      "title": "% Reviewed by Copilot",
+      "description": "Share of PR review days where Copilot reviewed (vs total review days). Note: a PR may be reviewed on multiple days.",
+      "gridPos": {
+        "x": 16,
+        "y": 63,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_reviewed_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_reviewed')::int), 0), 1) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 124,
+      "type": "timeseries",
+      "title": "PRs Reviewed — Daily (Total vs Copilot)",
+      "description": "Daily trend of total PRs reviewed vs PRs reviewed by Copilot.",
+      "gridPos": {
+        "x": 0,
+        "y": 68,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_reviewed')::int AS \"Total Reviewed\", (pull_requests->>'total_reviewed_by_copilot')::int AS \"Reviewed by Copilot\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 125,
+      "type": "text",
+      "title": "Pull Request Review — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 76,
+        "w": 24,
+        "h": 27
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_reviewed` and `pull_requests.total_reviewed_by_copilot`.\n\n**Important:** A PR is counted on **every day** it receives a review action (so totals can exceed unique-PR counts). Within a single day each PR is counted at most once.\n\n**Calculation:**\n- Stat panels sum each field across the last 28 days.\n- Percent gauge: `SUM(total_reviewed_by_copilot) / NULLIF(SUM(total_reviewed), 0) * 100`.\n\n**Why time-series:** Reveals whether Copilot review usage is sustained or sporadic. A flat-line at zero indicates Copilot code review is not enabled or not being requested.\n\n---\n\n### Underlying SQL\n\n**PRs Reviewed (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_reviewed')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**PRs Reviewed by Copilot (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_reviewed_by_copilot')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**% Reviewed by Copilot**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_reviewed_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_reviewed')::int), 0), 1) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**PRs Reviewed — Daily (Total vs Copilot)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_reviewed')::int AS \"Total Reviewed\", (pull_requests->>'total_reviewed_by_copilot')::int AS \"Reviewed by Copilot\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 302,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 103,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 130,
+      "type": "row",
+      "collapsed": false,
+      "title": "Copilot Code Review Engagement (Active vs Passive) — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 104,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 131,
+      "type": "stat",
+      "title": "Monthly Active Code Review Users",
+      "description": "monthly_active_copilot_code_review_users — users who manually requested a Copilot review or applied a Copilot review suggestion in the 28-day window.",
+      "gridPos": {
+        "x": 0,
+        "y": 105,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT monthly_active_copilot_code_review_users AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND monthly_active_copilot_code_review_users IS NOT NULL ORDER BY day DESC LIMIT 1"
+        }
+      ]
+    },
+    {
+      "id": 132,
+      "type": "stat",
+      "title": "Monthly Passive Code Review Users",
+      "description": "monthly_passive_copilot_code_review_users — users who had Copilot auto-assigned to review their PR but did not actively engage.",
+      "gridPos": {
+        "x": 8,
+        "y": 105,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT monthly_passive_copilot_code_review_users AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND monthly_passive_copilot_code_review_users IS NOT NULL ORDER BY day DESC LIMIT 1"
+        }
+      ]
+    },
+    {
+      "id": 133,
+      "type": "gauge",
+      "title": "Active Engagement Rate",
+      "description": "active / (active + passive) — high values mean developers actively use Copilot reviews; low values mean Copilot is auto-assigning but being ignored.",
+      "gridPos": {
+        "x": 16,
+        "y": 105,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 25
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 75
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * monthly_active_copilot_code_review_users / NULLIF(monthly_active_copilot_code_review_users + monthly_passive_copilot_code_review_users, 0), 1) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND monthly_active_copilot_code_review_users IS NOT NULL AND monthly_passive_copilot_code_review_users IS NOT NULL ORDER BY day DESC LIMIT 1"
+        }
+      ]
+    },
+    {
+      "id": 134,
+      "type": "timeseries",
+      "title": "Daily Code Review Users — Active vs Passive",
+      "description": "Daily trend of active vs passive Copilot code review users.",
+      "gridPos": {
+        "x": 0,
+        "y": 110,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, daily_active_copilot_code_review_users AS \"Active\", daily_passive_copilot_code_review_users AS \"Passive\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 135,
+      "type": "text",
+      "title": "Copilot Code Review Engagement — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 118,
+        "w": 24,
+        "h": 26
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API fields (API only — not in built-in dashboard):**\n- `daily_active_copilot_code_review_users` / `monthly_active_copilot_code_review_users` — actively engaged (manually requested a review or applied a review suggestion).\n- `daily_passive_copilot_code_review_users` / `monthly_passive_copilot_code_review_users` — auto-assigned but did not engage.\n\n**Active Engagement Rate** = `active / (active + passive)`. A high passive count with low active rate is a leading indicator that Copilot reviews are being ignored — a coaching/enablement opportunity.\n\n**Why time-series:** Shows whether engagement is improving as teams adopt the feature, or whether passive auto-assignments are growing without corresponding active use.\n\n---\n\n### Underlying SQL\n\n**Monthly Active Code Review Users**\n\n```sql\nSELECT monthly_active_copilot_code_review_users AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND monthly_active_copilot_code_review_users IS NOT NULL\nORDER BY day DESC LIMIT 1\n```\n\n**Monthly Passive Code Review Users**\n\n```sql\nSELECT monthly_passive_copilot_code_review_users AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND monthly_passive_copilot_code_review_users IS NOT NULL\nORDER BY day DESC LIMIT 1\n```\n\n**Active Engagement Rate**\n\n```sql\nSELECT ROUND(100.0 * monthly_active_copilot_code_review_users / NULLIF(monthly_active_copilot_code_review_users + monthly_passive_copilot_code_review_users, 0), 1) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND monthly_active_copilot_code_review_users IS NOT NULL AND monthly_passive_copilot_code_review_users IS NOT NULL\nORDER BY day DESC LIMIT 1\n```\n\n**Daily Code Review Users — Active vs Passive**\n\n```sql\nSELECT day AS time, daily_active_copilot_code_review_users AS \"Active\", daily_passive_copilot_code_review_users AS \"Passive\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 303,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 144,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 140,
+      "type": "row",
+      "collapsed": false,
+      "title": "Pull Request Merge & Lead Time — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 145,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 141,
+      "type": "stat",
+      "title": "PRs Merged (28d)",
+      "description": "pull_requests.total_merged summed over the last 28 days.",
+      "gridPos": {
+        "x": 0,
+        "y": 146,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_merged')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 142,
+      "type": "stat",
+      "title": "PRs Merged that Copilot Created (28d)",
+      "description": "pull_requests.total_merged_created_by_copilot summed over the last 28 days.",
+      "gridPos": {
+        "x": 8,
+        "y": 146,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_merged_created_by_copilot')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 143,
+      "type": "gauge",
+      "title": "% Merged that Copilot Created",
+      "description": "Share of merged PRs that were created by Copilot.",
+      "gridPos": {
+        "x": 16,
+        "y": 146,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_merged_created_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_merged')::int), 0), 1) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 144,
+      "type": "timeseries",
+      "title": "PRs Merged — Daily (Total vs Copilot-Authored)",
+      "description": "Daily trend of total merged PRs vs Copilot-authored merged PRs.",
+      "gridPos": {
+        "x": 0,
+        "y": 151,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_merged')::int AS \"Total Merged\", (pull_requests->>'total_merged_created_by_copilot')::int AS \"Copilot-Authored Merged\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 145,
+      "type": "timeseries",
+      "title": "Median Minutes to Merge — All vs Copilot-Authored",
+      "description": "Daily median minutes from PR creation to merge — overall vs Copilot-authored. Reveals lead-time drift between human-authored and Copilot-authored PRs.",
+      "gridPos": {
+        "x": 0,
+        "y": 159,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'median_minutes_to_merge')::numeric AS \"All PRs\", (pull_requests->>'median_minutes_to_merge_copilot_authored')::numeric AS \"Copilot-Authored\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 146,
+      "type": "text",
+      "title": "Pull Request Merge & Lead Time — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 167,
+        "w": 24,
+        "h": 31
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_merged`, `pull_requests.total_merged_created_by_copilot`, `pull_requests.median_minutes_to_merge`, `pull_requests.median_minutes_to_merge_copilot_authored`.\n\n**Calculation:** Each PR is counted on the day it was merged (one-time event). Median values are *daily medians* reported by GitHub — do not average them across days; chart them as a trend.\n\n**Why two time-series:** The *count* trend shows merge throughput; the *median minutes to merge* trend reveals whether Copilot-authored PRs are getting through review faster or slower than human-authored ones over time. A widening gap is a leading signal worth investigating.\n\n---\n\n### Underlying SQL\n\n**PRs Merged (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_merged')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**PRs Merged that Copilot Created (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_merged_created_by_copilot')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**% Merged that Copilot Created**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_merged_created_by_copilot')::int) / NULLIF(SUM((pull_requests->>'total_merged')::int), 0), 1) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**PRs Merged — Daily (Total vs Copilot-Authored)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_merged')::int AS \"Total Merged\", (pull_requests->>'total_merged_created_by_copilot')::int AS \"Copilot-Authored Merged\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```\n\n**Median Minutes to Merge — All vs Copilot-Authored**\n\n```sql\nSELECT day AS time, (pull_requests->>'median_minutes_to_merge')::numeric AS \"All PRs\", (pull_requests->>'median_minutes_to_merge_copilot_authored')::numeric AS \"Copilot-Authored\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 304,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 198,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 150,
+      "type": "row",
+      "collapsed": false,
+      "title": "PR Review Suggestions — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 199,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 151,
+      "type": "stat",
+      "title": "Total PR Review Suggestions (28d)",
+      "description": "pull_requests.total_suggestions — review suggestions generated by any author.",
+      "gridPos": {
+        "x": 0,
+        "y": 200,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_suggestions')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 152,
+      "type": "stat",
+      "title": "Copilot PR Suggestions (28d)",
+      "description": "pull_requests.total_copilot_suggestions — review suggestions generated by Copilot.",
+      "gridPos": {
+        "x": 8,
+        "y": 200,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_copilot_suggestions')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 153,
+      "type": "gauge",
+      "title": "% Suggestions from Copilot",
+      "description": "Share of PR review suggestions generated by Copilot.",
+      "gridPos": {
+        "x": 16,
+        "y": 200,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_copilot_suggestions')::int) / NULLIF(SUM((pull_requests->>'total_suggestions')::int), 0), 1) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 154,
+      "type": "timeseries",
+      "title": "PR Review Suggestions — Daily (Total vs Copilot)",
+      "description": "Daily trend of all review suggestions vs Copilot-generated suggestions.",
+      "gridPos": {
+        "x": 0,
+        "y": 205,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_suggestions')::int AS \"Total\", (pull_requests->>'total_copilot_suggestions')::int AS \"Copilot\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 155,
+      "type": "text",
+      "title": "PR Review Suggestions — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 213,
+        "w": 24,
+        "h": 25
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_suggestions` (any author) and `pull_requests.total_copilot_suggestions` (Copilot only).\n\n**Calculation:** Sums of suggestions generated each day; the percent gauge is `copilot / total`.\n\n**Pair this with the Applied Suggestions section below** — high suggestion volume with a low apply rate suggests the suggestions are noisy or low-quality. High volume + high apply rate is the signal of healthy Copilot review adoption.\n\n---\n\n### Underlying SQL\n\n**Total PR Review Suggestions (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_suggestions')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**Copilot PR Suggestions (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_copilot_suggestions')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**% Suggestions from Copilot**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_copilot_suggestions')::int) / NULLIF(SUM((pull_requests->>'total_suggestions')::int), 0), 1) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**PR Review Suggestions — Daily (Total vs Copilot)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_suggestions')::int AS \"Total\", (pull_requests->>'total_copilot_suggestions')::int AS \"Copilot\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 305,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 238,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 160,
+      "type": "row",
+      "collapsed": false,
+      "title": "Applied PR Suggestions (Apply Rate) — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 239,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 161,
+      "type": "stat",
+      "title": "Applied Suggestions — All (28d)",
+      "description": "pull_requests.total_applied_suggestions — review suggestions applied (any author).",
+      "gridPos": {
+        "x": 0,
+        "y": 240,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_applied_suggestions')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 162,
+      "type": "stat",
+      "title": "Applied Copilot Suggestions (28d)",
+      "description": "pull_requests.total_copilot_applied_suggestions — Copilot-generated suggestions that were applied.",
+      "gridPos": {
+        "x": 8,
+        "y": 240,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT SUM((pull_requests->>'total_copilot_applied_suggestions')::int) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 163,
+      "type": "gauge",
+      "title": "Copilot Suggestion Apply Rate",
+      "description": "applied_copilot / generated_copilot — high values mean reviewers find Copilot's suggestions useful and accept them.",
+      "gridPos": {
+        "x": 16,
+        "y": 240,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 40
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "rawSql": "SELECT ROUND(100.0 * SUM((pull_requests->>'total_copilot_applied_suggestions')::int) / NULLIF(SUM((pull_requests->>'total_copilot_suggestions')::int), 0), 1) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id')"
+        }
+      ]
+    },
+    {
+      "id": 164,
+      "type": "timeseries",
+      "title": "Copilot Suggestions — Daily (Generated vs Applied)",
+      "description": "Daily trend of Copilot suggestions generated vs applied. The gap reveals quality and engagement.",
+      "gridPos": {
+        "x": 0,
+        "y": 245,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, (pull_requests->>'total_copilot_suggestions')::int AS \"Generated\", (pull_requests->>'total_copilot_applied_suggestions')::int AS \"Applied\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 165,
+      "type": "text",
+      "title": "Applied PR Suggestions — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 253,
+        "w": 24,
+        "h": 25
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**API source:** `pull_requests.total_applied_suggestions` (any author) and `pull_requests.total_copilot_applied_suggestions` (Copilot only).\n\n**Apply Rate:** `total_copilot_applied_suggestions / NULLIF(total_copilot_suggestions, 0) * 100` — the most actionable single number on this dashboard. A low rate (< 10%) suggests Copilot's review feedback is being dismissed; investigate signal quality, model selection, or reviewer workflow.\n\n**Why time-series:** Generated-vs-applied gap over time shows whether reviewer trust in Copilot suggestions is growing, shrinking, or stable.\n\n---\n\n### Underlying SQL\n\n**Applied Suggestions — All (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_applied_suggestions')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**Applied Copilot Suggestions (28d)**\n\n```sql\nSELECT SUM((pull_requests->>'total_copilot_applied_suggestions')::int) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**Copilot Suggestion Apply Rate**\n\n```sql\nSELECT ROUND(100.0 * SUM((pull_requests->>'total_copilot_applied_suggestions')::int) / NULLIF(SUM((pull_requests->>'total_copilot_suggestions')::int), 0), 1) AS value\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\n```\n\n**Copilot Suggestions — Daily (Generated vs Applied)**\n\n```sql\nSELECT day AS time, (pull_requests->>'total_copilot_suggestions')::int AS \"Generated\", (pull_requests->>'total_copilot_applied_suggestions')::int AS \"Applied\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```"
+      }
+    },
+    {
+      "id": 306,
+      "type": "text",
+      "title": "",
+      "transparent": true,
+      "gridPos": {
+        "x": 0,
+        "y": 278,
+        "w": 24,
+        "h": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": ""
+      }
+    },
+    {
+      "id": 170,
+      "type": "row",
+      "collapsed": false,
+      "title": "API-Only Adoption Signals (CLI, Suggestions, Interactions) — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 279,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 171,
+      "type": "timeseries",
+      "title": "Daily Active CLI Users",
+      "description": "daily_active_cli_users — unique users who used Copilot via the CLI on each day. CLI usage is independent of IDE active-user counts and is API-only.",
+      "gridPos": {
+        "x": 0,
+        "y": 280,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "PostgreSQL"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, daily_active_cli_users AS \"Daily Active CLI Users\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
+        }
+      ]
+    },
+    {
+      "id": 172,
+      "type": "timeseries",
+      "title": "Total User-Initiated Interactions",
+      "description": "user_initiated_interaction_count — daily count of explicit prompts sent to Copilot. Excludes UI events like opening the chat panel or switching modes. API-only.",
       "gridPos": {
         "x": 12,
-        "y": 0,
-        "w": 6,
-        "h": 4
+        "y": 280,
+        "w": 12,
+        "h": 8
       },
       "datasource": {
         "type": "grafana-postgresql-datasource",
@@ -96,20 +1140,21 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT SUM(loc_suggested_to_add_sum) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily)",
-          "format": "table"
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, user_initiated_interaction_count AS \"User-Initiated Interactions\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
         }
       ]
     },
     {
-      "id": 4,
-      "type": "stat",
-      "title": "Lines of Code Added",
+      "id": 173,
+      "type": "timeseries",
+      "title": "Lines of Code Suggested — Add vs Delete",
+      "description": "loc_suggested_to_add_sum and loc_suggested_to_delete_sum — what Copilot proposed vs what was kept (compare with the LoC accepted metrics on the built-in dashboard).",
       "gridPos": {
-        "x": 18,
-        "y": 0,
-        "w": 6,
-        "h": 4
+        "x": 0,
+        "y": 288,
+        "w": 24,
+        "h": 8
       },
       "datasource": {
         "type": "grafana-postgresql-datasource",
@@ -118,10 +1163,25 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT SUM(loc_added_sum) AS value FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily)",
-          "format": "table"
+          "format": "time_series",
+          "rawSql": "SELECT day AS time, loc_suggested_to_add_sum AS \"Suggested to Add\", loc_suggested_to_delete_sum AS \"Suggested to Delete\" FROM copilot_organization_daily WHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days' FROM copilot_organization_daily WHERE organization_id = '$organization_id') ORDER BY day"
         }
       ]
+    },
+    {
+      "id": 174,
+      "type": "text",
+      "title": "API-Only Adoption Signals — Learning Guide",
+      "gridPos": {
+        "x": 0,
+        "y": 296,
+        "w": 24,
+        "h": 21
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**Why these are here:** Each of these fields is **API-only** — none appear on the built-in Copilot Usage dashboard at `/orgs/<org>/insights/copilot/usage`.\n\n- `daily_active_cli_users` — CLI surface area is independent of IDE; growth here indicates terminal-driven workflows.\n- `user_initiated_interaction_count` — explicit prompts only. Distinct from `code_generation_activity_count` because one prompt can produce multiple generations.\n- `loc_suggested_to_add_sum` / `loc_suggested_to_delete_sum` — what Copilot *offered*, not what was kept. Compare with `loc_added_sum` / `loc_deleted_sum` on the built-in dashboard to estimate take-up rate.\n\n---\n\n### Underlying SQL\n\n**Daily Active CLI Users**\n\n```sql\nSELECT day AS time, daily_active_cli_users AS \"Daily Active CLI Users\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```\n\n**Total User-Initiated Interactions**\n\n```sql\nSELECT day AS time, user_initiated_interaction_count AS \"User-Initiated Interactions\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```\n\n**Lines of Code Suggested — Add vs Delete**\n\n```sql\nSELECT day AS time, loc_suggested_to_add_sum AS \"Suggested to Add\", loc_suggested_to_delete_sum AS \"Suggested to Delete\"\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id' AND day >= (SELECT MAX(day) - INTERVAL '27 days'\nFROM copilot_organization_daily\nWHERE organization_id = '$organization_id')\nORDER BY day\n```"
+      }
     }
   ]
 }


### PR DESCRIPTION
Replaces the auto-generated per-user leading-indicator dashboards on `master` with the validated PR-metrics + code-review versions.

## Changes
- **`v3/grafana/dashboards/10-enterprise-copilot-leading.json`** — rebuilt with PR throughput + Copilot code-review engagement panels.
- **`v3/grafana/dashboards/11-organization-copilot-leading.json`** — same rebuild, plus SQL fix: code-review user stats (Monthly Active/Passive Code Review Users, Active Engagement Rate) now use `ORDER BY day DESC LIMIT 1` instead of `MAX(monthly_*)` over the 28-day window. Each row already represents a 28-day rolling counter, so taking `MAX` over the window mixed values from different rolling windows.
- Added enterprise dashboard JSON exports (`enterprise.json`, `v3/enterprise-dashboard-raw.json`, `v3/enterprise-dashboard.json`) for reference.

## Validation
- Visual: validated locally at http://localhost:3006/d/edu-organization-leading and http://localhost:3006/d/edu-enterprise-leading.
- SQL spot-check against live DB: latest-day code-review values (879 / 629 / 650, rate 37.0%) match expected.

## Note
This branch supersedes commit 352ff92 currently on `master` (the auto-generated per-user rebuild). Merging this PR will require resolving conflicts on the two dashboard JSON files in favor of this branch.