### PR TITLE
chore: harden screenshot-embed flow and ignore Playwright artifacts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,12 +123,15 @@ When making changes to dashboard JSON or Grafana SQL, always capture **before** 
 
 #### Cloud agent sessions (Playwright MCP available)
 
-**Playwright MCP is configured** — use it directly. Do NOT write Node.js scripts or install `@playwright/cli` separately.
+**Playwright MCP is a [default MCP server](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/mcp-and-cloud-agent#default-mcp-servers) for every cloud-agent session** — it is always available, ships with its own bundled browser, and has access to `localhost` / `127.0.0.1` (which is exactly where Grafana runs at `http://localhost:3006`). Call its tools directly (`browser_navigate`, `browser_take_screenshot`). **Do NOT** run `npx playwright install`, do NOT write Node.js capture scripts, and do NOT use the project's own `@playwright/test` install for screenshots — that is a separate Playwright instance used by `npm run test:e2e` and is unrelated to screenshot capture.
 
-1. **Before** making changes — navigate to the affected Grafana dashboard URL, wait for panels to load, and capture the screenshot.
-2. **Make** the changes.
-3. **After** applying changes — reload and capture the after screenshot.
-4. Embed both in the PR description under a `## Visual verification` section (see [Screenshots in PR descriptions](#screenshots-in-pr-descriptions)).
+Order of operations is strict — the visual-verification step **must complete before** `npm run test:e2e` so that a test-suite failure cannot skip the screenshot embed:
+
+1. **Before** making changes — navigate to the affected Grafana dashboard URL with Playwright MCP, wait for panels to load, and capture the "before" screenshot.
+2. **Make** the changes (edit dashboard JSON / Grafana SQL).
+3. **After** applying changes — reload and capture the "after" screenshot.
+4. **Upload and embed** both screenshots in the PR description under a `## Visual verification` section using `https://github.com/user-attachments/assets/<uuid>` URLs (see [Screenshots in PR descriptions](#screenshots-in-pr-descriptions) for the exact format and verification rules).
+5. **Only then** run `npm run build && npm run test:e2e` and finalize the PR. If `test:e2e` fails, do not delete or skip the already-embedded screenshots — fix the test failure and re-run.
 
 #### Local agent sessions (no Playwright MCP)
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ node_modules/
 dist/
 .env
 data/raw/
+# Playwright + screenshot artifacts must never be committed.
+# Screenshots embed in PR bodies via user-attachments uploads (see .github/copilot-instructions.md).
+playwright-report/
+test-results/
+screenshots/


### PR DESCRIPTION
## Why

Two defenses against the failure mode seen in [PR #117](https://github.com/nicolehaugen/CustomMetricsDashboard/pull/117) and [PR #113](https://github.com/nicolehaugen/CustomMetricsDashboard/pull/113): CI failure artifacts ended up in the PR diff and no screenshots were embedded even though Playwright MCP was available.

## What

### 1. `.gitignore` — ignore Playwright/screenshot artifacts

- `playwright-report/`, `test-results/` are produced by `npm run test:e2e` and should never be in a PR diff.
- `screenshots/` is the historical anti-pattern (committed PNGs); screenshots embed via `user-attachments` uploads instead.

### 2. `copilot-instructions.md` — explicit, ordered screenshot flow

- Cite the GitHub docs confirming **Playwright MCP is a [default MCP server](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/mcp-and-cloud-agent#default-mcp-servers)** for every cloud-agent session — bundled browser, `localhost`/`127.0.0.1` access. No install required.
- Distinguish it from the project's `@playwright/test` install used by `npm run test:e2e` (which **is** a separate thing and is unrelated to screenshot capture).
- Make the order strict: **capture → edit → re-capture → upload+embed → only then run `test:e2e`.** A `test:e2e` failure cannot short-circuit the screenshot embed because the embed has already happened.