### PR TITLE
feat: ephemeral demo env automation (use-demo.sh, create-demo.sh, refresh-demo-env skill)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ GITHUB_ENTERPRISE=your-enterprise-slug   # for Copilot metrics endpoints
 #   bash scripts/use-demo.sh          # reconfigure to your current provisioned demo
 #   bash scripts/create-demo.sh       # create a new demo + wait + reconfigure
 # See the refresh-demo-env Copilot skill for agent-driven automation.
-GITHUB_ORG=Octodemo                      # for DORA data + Copilot seats
+GITHUB_ORG=octodemo                      # for DORA data + Copilot seats
 GITHUB_REPO=octocat_supply-curly-train   # for DORA data
 
 # PostgreSQL (matches docker-compose defaults)

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ GITHUB_TOKEN=ghp_your_token_here
 
 # GitHub targets
 GITHUB_ENTERPRISE=your-enterprise-slug   # for Copilot metrics endpoints
+# GITHUB_ORG and GITHUB_REPO point to the octodemo/bootstrap demo environment.
+# To update them automatically after creating or refreshing a demo, run:
+#   bash scripts/use-demo.sh          # reconfigure to your current provisioned demo
+#   bash scripts/create-demo.sh       # create a new demo + wait + reconfigure
+# See the refresh-demo-env Copilot skill for agent-driven automation.
 GITHUB_ORG=Octodemo                      # for DORA data + Copilot seats
 GITHUB_REPO=octocat_supply-curly-train   # for DORA data
 

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@ GITHUB_TOKEN=ghp_your_token_here
 
 # GitHub targets
 GITHUB_ENTERPRISE=your-enterprise-slug   # for Copilot metrics endpoints
-# GITHUB_ORG and GITHUB_REPO point to the octodemo/bootstrap demo environment.
+# If using an octodemo/bootstrap demo environment, GITHUB_ORG and GITHUB_REPO
+# are managed by the refresh-demo-env scripts. Otherwise, set them to any
+# GitHub org/repo you want to track.
 # To update them automatically after creating or refreshing a demo, run:
 #   bash scripts/use-demo.sh          # reconfigure to your current provisioned demo
 #   bash scripts/create-demo.sh       # create a new demo + wait + reconfigure

--- a/.github/skills/refresh-demo-env/SKILL.md
+++ b/.github/skills/refresh-demo-env/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: refresh-demo-env
+description: "**WORKFLOW SKILL** — Reconfigure the CustomMetricsDashboard to point at the user's current octodemo/bootstrap demo environment, triggering a fresh data sync. WHEN: 'refresh demo env', 'dashboard data is stale', 'update demo environment', 'point dashboard at my demo', 'new demo was provisioned', 'weekly demo refresh'. INVOKES: gh CLI for bootstrap issue discovery, scripts/use-demo.sh or scripts/create-demo.sh, docker compose, sync server. FOR SINGLE OPERATIONS: run bash scripts/use-demo.sh directly if a demo::provisioned issue already exists."
+---
+
+# Refresh Demo Environment
+
+Reconfigure the CustomMetricsDashboard's `.env` to point at the user's current
+`octodemo/bootstrap`-provisioned demo, then trigger a fresh data sync so
+Grafana reflects the new environment.
+
+## Background
+
+Demo environments in `octodemo/bootstrap` are ephemeral — they are torn down
+weekly by an expiry workflow. After each teardown the user must create a new
+one (via `octodemo/bootstrap` issue) and reconfigure the dashboard. This
+skill automates that entire workflow.
+
+The dashboard reads `GITHUB_ORG` and `GITHUB_REPO` from `.env` at container
+start. Changing those two values + restarting the sync-server container + POST
+`/sync` is all it takes to point every dashboard panel at a new environment.
+`GITHUB_ENTERPRISE` is **not** updated — it stays constant across all demos.
+
+## Step 1 — Pre-checks
+
+Before running any scripts, verify:
+
+1. **Docker Desktop is running:**
+   ```bash
+   docker info
+   ```
+   If not, ask the user to start it.
+
+2. **Working directory is the repo root:**
+   Scripts must run from `C:\Repos\CustomMetricsDashboard` (or wherever the
+   repo is checked out). Both scripts resolve their own path, so `cd` is only
+   needed for `docker compose`.
+
+3. **`.env` exists:**
+   ```bash
+   ls .env
+   ```
+   If missing, invoke the `setup-env` skill first.
+
+## Step 2 — Decide: use existing demo or create a new one?
+
+Run this single API call to check for an active provisioned demo:
+
+```bash
+COUNT=$(gh api -X GET /repos/octodemo/bootstrap/issues \
+  -f labels=demo::provisioned \
+  -f state=open \
+  -f creator="$(gh api /user --jq .login)" \
+  --jq length)
+echo "Active demos: $COUNT"
+```
+
+Determine demo age if `$COUNT >= 1`:
+```bash
+UPDATED=$(gh api -X GET /repos/octodemo/bootstrap/issues \
+  -f labels=demo::provisioned -f state=open \
+  -f creator="$(gh api /user --jq .login)" \
+  -f per_page=1 -f sort=updated -f direction=desc \
+  --jq '.[0].updated_at')
+echo "Demo last updated: $UPDATED"
+```
+
+**Decision tree:**
+
+| Condition | Action |
+|-----------|--------|
+| `$COUNT >= 1` AND demo updated < 6 days ago | Run `use-demo.sh` — just reconfigure |
+| `$COUNT == 0` OR demo is 6+ days old (likely expiring soon) | Run `create-demo.sh` — create new + wait + reconfigure |
+
+## Step 3a — Use existing demo
+
+```bash
+bash scripts/use-demo.sh
+```
+
+Captures and parses the final JSON line (last line of stdout). All log lines
+go to stderr.
+
+## Step 3b — Create new demo (if needed)
+
+```bash
+bash scripts/create-demo.sh
+```
+
+This creates an issue in `octodemo/bootstrap`, polls for the `demo::provisioned`
+label (up to 20 minutes), then exec-replaces itself with `use-demo.sh`.
+The final JSON output is identical to Step 3a.
+
+## Step 4 — Parse and report output
+
+Both scripts emit a single JSON line as their last stdout line:
+
+**Success:**
+```json
+{"status":"success","action":"use","newOrg":"octodemo","newRepo":"octocat_supply-<slug>","issueUrl":"https://github.com/octodemo/bootstrap/issues/<n>","grafanaUrl":"http://localhost:3006/d/overview"}
+```
+
+**Error:**
+```json
+{"status":"error","code":"ERR_...","message":"...","hint":"..."}
+```
+
+Parse the last stdout line:
+```bash
+RESULT=$(bash scripts/use-demo.sh 2>/dev/null | tail -1)
+STATUS=$(echo "$RESULT" | grep -o '"status":"[^"]*"' | sed 's/"status":"//;s/"$//')
+```
+
+On `status: success`, report to the user:
+- `newOrg/newRepo` — the new target
+- `grafanaUrl` — open Grafana to verify data
+
+## Step 5 — Error routing
+
+| Code | What happened | What to do |
+|------|--------------|------------|
+| `ERR_GH_AUTH` | `gh` CLI is not authenticated or can't reach `octodemo/bootstrap` | Run `gh auth login --hostname github.com` |
+| `ERR_NO_TOKEN` | `.env` is missing or has no `GITHUB_TOKEN` | Invoke the `setup-env` skill |
+| `ERR_DASHBOARD_TOKEN_INVALID` | `GITHUB_TOKEN` in `.env` is expired (got 401) | Invoke the `setup-env` skill to update the token |
+| `ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS` | Token can't read the new demo repo (404/403) | Ensure the PAT owner is a member of `octodemo`; wait if the demo just started provisioning |
+| `ERR_NO_PROVISIONED_DEMO` | No open `demo::provisioned` issue for this user | Run `create-demo.sh` |
+| `ERR_PROVISION_TIMEOUT` | Bootstrap workflow didn't label the issue within 20min | The `issueUrl` field in the JSON has the issue URL; check the Actions run in `octodemo/bootstrap`. When ready, re-run: `bash scripts/use-demo.sh --issue <n>` |
+| `ERR_DOCKER_NOT_RUNNING` | Docker daemon is not running | Start Docker Desktop |
+| `ERR_SYNC_FAILED` | Sync server errored or didn't start | Check: `docker compose logs sync-server` |
+| `ERR_SYNC_DID_NOT_PERSIST` | Sync completed but `app_config.repo` doesn't match | Check: `docker compose logs sync-server \| tail -50`; may need manual re-sync |
+
+## Important
+
+- **Do NOT echo `GITHUB_TOKEN`** back to the user. The token is in `.env`
+  and the script reads it directly — you never need to display it.
+- `GITHUB_ENTERPRISE` is **never changed** by these scripts. It is constant
+  across all `octodemo` demo environments.
+- The scripts are idempotent — running `use-demo.sh` twice in a row when
+  `.env` already points at the right repo is a safe no-op (it still triggers
+  a fresh sync, which refreshes data).
+- Demo environments are in the **private** `octodemo` org. The bootstrap repo
+  and provisioned repos are only accessible to `octodemo` members.

--- a/.github/skills/refresh-demo-env/SKILL.md
+++ b/.github/skills/refresh-demo-env/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refresh-demo-env
-description: "**WORKFLOW SKILL** — Reconfigure the CustomMetricsDashboard to point at the user's current octodemo/bootstrap demo environment. WHEN: 'refresh demo env', 'dashboard data is stale', 'update demo environment', 'point dashboard at my demo', 'new demo was provisioned', 'weekly demo refresh'. INVOKES: gh CLI for bootstrap issue discovery, scripts/use-demo.sh or scripts/create-demo.sh. FOR SINGLE OPERATIONS: run bash scripts/use-demo.sh directly if a demo::provisioned issue already exists."
+description: "**WORKFLOW SKILL** — Reconfigure CustomMetricsDashboard `.env` to point at the user's current octodemo/bootstrap demo environment, then report the manual restart + `/sync` steps. WHEN: 'refresh demo env', 'dashboard data is stale', 'update demo environment', 'point dashboard at my demo', 'new demo was provisioned', 'weekly demo refresh'. INVOKES: gh CLI for bootstrap issue discovery, scripts/use-demo.sh or scripts/create-demo.sh. FOR SINGLE OPERATIONS: run bash scripts/use-demo.sh directly if a demo::provisioned issue already exists."
 ---
 
 # Refresh Demo Environment
@@ -13,7 +13,9 @@ Reconfigure the CustomMetricsDashboard's `.env` to point at the user's current
 Demo environments in `octodemo/bootstrap` are ephemeral — they are torn down
 weekly by an expiry workflow. After each teardown the user must create a new
 one (via `octodemo/bootstrap` issue) and reconfigure the dashboard. This
-skill automates that entire workflow.
+skill automates the reconfiguration step: it updates `.env` with the new org
+and repo. The user must then manually restart the sync-server container and
+POST `/sync` to complete the refresh.
 
 The dashboard reads `GITHUB_ORG` and `GITHUB_REPO` from `.env` at container
 start. The scripts update those two values; the user must then manually restart
@@ -135,7 +137,7 @@ On `status: success`, report to the user:
 | `ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS` | Token can't read the new demo repo (404/403) | Ensure the PAT owner is a member of `octodemo`; wait if the demo just started provisioning |
 | `ERR_NO_PROVISIONED_DEMO` | No open `demo::provisioned` issue for this user | Run `create-demo.sh` |
 | `ERR_PROVISION_TIMEOUT` | Bootstrap workflow didn't label the issue within 20min | The `issueUrl` field in the JSON has the issue URL; check the Actions run in `octodemo/bootstrap`. When ready, re-run: `bash scripts/use-demo.sh --issue <n>` |
-| `ERR_BAD_ISSUE_TITLE` | Issue title doesn't match expected format | Verify the bootstrap issue title follows the pattern `Demo for <repo-slug>` |
+| `ERR_BAD_ISSUE_TITLE` | Issue title doesn't match expected format | Verify the bootstrap issue title follows the pattern `Demo :: <repo-slug> :: <version> :: <actor>` |
 | `ERR_INVALID_ARGS` | `use-demo.sh` was called with an unknown flag or missing `--issue` value | Re-run with `bash scripts/use-demo.sh [--issue <number>]` |
 
 ## Important

--- a/.github/skills/refresh-demo-env/SKILL.md
+++ b/.github/skills/refresh-demo-env/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: refresh-demo-env
-description: "**WORKFLOW SKILL** — Reconfigure the CustomMetricsDashboard to point at the user's current octodemo/bootstrap demo environment, triggering a fresh data sync. WHEN: 'refresh demo env', 'dashboard data is stale', 'update demo environment', 'point dashboard at my demo', 'new demo was provisioned', 'weekly demo refresh'. INVOKES: gh CLI for bootstrap issue discovery, scripts/use-demo.sh or scripts/create-demo.sh, docker compose, sync server. FOR SINGLE OPERATIONS: run bash scripts/use-demo.sh directly if a demo::provisioned issue already exists."
+description: "**WORKFLOW SKILL** — Reconfigure the CustomMetricsDashboard to point at the user's current octodemo/bootstrap demo environment. WHEN: 'refresh demo env', 'dashboard data is stale', 'update demo environment', 'point dashboard at my demo', 'new demo was provisioned', 'weekly demo refresh'. INVOKES: gh CLI for bootstrap issue discovery, scripts/use-demo.sh or scripts/create-demo.sh. FOR SINGLE OPERATIONS: run bash scripts/use-demo.sh directly if a demo::provisioned issue already exists."
 ---
 
 # Refresh Demo Environment
 
 Reconfigure the CustomMetricsDashboard's `.env` to point at the user's current
-`octodemo/bootstrap`-provisioned demo, then trigger a fresh data sync so
-Grafana reflects the new environment.
+`octodemo/bootstrap`-provisioned demo.
 
 ## Background
 
@@ -17,8 +16,8 @@ one (via `octodemo/bootstrap` issue) and reconfigure the dashboard. This
 skill automates that entire workflow.
 
 The dashboard reads `GITHUB_ORG` and `GITHUB_REPO` from `.env` at container
-start. Changing those two values + restarting the sync-server container + POST
-`/sync` is all it takes to point every dashboard panel at a new environment.
+start. The scripts update those two values; the user must then manually restart
+the sync-server container and POST `/sync` to complete the reconfiguration.
 `GITHUB_ENTERPRISE` is **not** updated — it stays constant across all demos.
 
 ## Step 1 — Pre-checks
@@ -32,9 +31,9 @@ Before running any scripts, verify:
    If not, ask the user to start it.
 
 2. **Working directory is the repo root:**
-   Scripts must run from `C:\Repos\CustomMetricsDashboard` (or wherever the
-   repo is checked out). Both scripts resolve their own path, so `cd` is only
-   needed for `docker compose`.
+   The scripts resolve their own path and can be invoked from any directory.
+   However, `docker compose` commands (used in the manual steps after the
+   script completes) must be run from the repo root.
 
 3. **`.env` exists:**
    ```bash
@@ -79,8 +78,13 @@ bash scripts/use-demo.sh
 ```
 
 Captures and parses the final JSON line (last line of stdout). All log lines
-go to stderr. On success the script prints the new org/repo — the user then
-restarts the stack and triggers a sync manually.
+go to stderr. On success the script prints the new org/repo. The user must then
+restart the stack and trigger a sync manually:
+
+```bash
+docker compose restart sync-server
+curl -X POST http://localhost:3005/sync
+```
 
 ## Step 3b — Create new demo (if needed)
 
@@ -90,7 +94,8 @@ bash scripts/create-demo.sh
 
 This creates an issue in `octodemo/bootstrap`, polls for the `demo::provisioned`
 label (up to 20 minutes), then exec-replaces itself with `use-demo.sh`.
-The final JSON output is identical to Step 3a.
+The final JSON output is identical to Step 3a. The user must manually restart
+and sync (see Step 3a).
 
 ## Step 4 — Parse and report output
 
@@ -98,7 +103,7 @@ Both scripts emit a single JSON line as their last stdout line:
 
 **Success:**
 ```json
-{"status":"success","action":"use","newOrg":"octodemo","newRepo":"octocat_supply-<slug>","issueUrl":"https://github.com/octodemo/bootstrap/issues/<n>","grafanaUrl":"http://localhost:3006/d/overview"}
+{"status":"success","action":"use","newOrg":"octodemo","newRepo":"octocat_supply-<slug>","issueUrl":"https://github.com/octodemo/bootstrap/issues/<n>"}
 ```
 
 **Error:**
@@ -114,7 +119,11 @@ STATUS=$(echo "$RESULT" | grep -o '"status":"[^"]*"' | sed 's/"status":"//;s/"$/
 
 On `status: success`, report to the user:
 - `newOrg/newRepo` — the new target
-- `grafanaUrl` — open Grafana to verify data
+- Remind them to restart the sync-server and trigger a sync:
+  ```bash
+  docker compose restart sync-server
+  curl -X POST http://localhost:3005/sync
+  ```
 
 ## Step 5 — Error routing
 
@@ -126,9 +135,7 @@ On `status: success`, report to the user:
 | `ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS` | Token can't read the new demo repo (404/403) | Ensure the PAT owner is a member of `octodemo`; wait if the demo just started provisioning |
 | `ERR_NO_PROVISIONED_DEMO` | No open `demo::provisioned` issue for this user | Run `create-demo.sh` |
 | `ERR_PROVISION_TIMEOUT` | Bootstrap workflow didn't label the issue within 20min | The `issueUrl` field in the JSON has the issue URL; check the Actions run in `octodemo/bootstrap`. When ready, re-run: `bash scripts/use-demo.sh --issue <n>` |
-| `ERR_DOCKER_NOT_RUNNING` | Docker daemon is not running | Start Docker Desktop |
-| `ERR_SYNC_FAILED` | Sync server errored or didn't start | Check: `docker compose logs sync-server` |
-| `ERR_SYNC_DID_NOT_PERSIST` | Sync completed but `app_config.repo` doesn't match | Check: `docker compose logs sync-server \| tail -50`; may need manual re-sync |
+| `ERR_BAD_ISSUE_TITLE` | Issue title doesn't match expected format | Verify the bootstrap issue title follows the pattern `Demo for <repo-slug>` |
 
 ## Important
 
@@ -137,7 +144,6 @@ On `status: success`, report to the user:
 - `GITHUB_ENTERPRISE` is **never changed** by these scripts. It is constant
   across all `octodemo` demo environments.
 - The scripts are idempotent — running `use-demo.sh` twice in a row when
-  `.env` already points at the right repo is a safe no-op (it still triggers
-  a fresh sync, which refreshes data).
+  `.env` already points at the right repo is a safe no-op.
 - Demo environments are in the **private** `octodemo` org. The bootstrap repo
   and provisioned repos are only accessible to `octodemo` members.

--- a/.github/skills/refresh-demo-env/SKILL.md
+++ b/.github/skills/refresh-demo-env/SKILL.md
@@ -84,7 +84,7 @@ go to stderr. On success the script prints the new org/repo. The user must then
 restart the stack and trigger a sync manually:
 
 ```bash
-docker compose restart sync-server
+docker compose up -d sync-server
 curl -X POST http://localhost:3005/sync
 ```
 
@@ -123,7 +123,7 @@ On `status: success`, report to the user:
 - `newOrg/newRepo` — the new target
 - Remind them to restart the sync-server and trigger a sync:
   ```bash
-  docker compose restart sync-server
+  docker compose up -d sync-server
   curl -X POST http://localhost:3005/sync
   ```
 

--- a/.github/skills/refresh-demo-env/SKILL.md
+++ b/.github/skills/refresh-demo-env/SKILL.md
@@ -79,7 +79,8 @@ bash scripts/use-demo.sh
 ```
 
 Captures and parses the final JSON line (last line of stdout). All log lines
-go to stderr.
+go to stderr. On success the script prints the new org/repo — the user then
+restarts the stack and triggers a sync manually.
 
 ## Step 3b — Create new demo (if needed)
 

--- a/.github/skills/refresh-demo-env/SKILL.md
+++ b/.github/skills/refresh-demo-env/SKILL.md
@@ -136,6 +136,7 @@ On `status: success`, report to the user:
 | `ERR_NO_PROVISIONED_DEMO` | No open `demo::provisioned` issue for this user | Run `create-demo.sh` |
 | `ERR_PROVISION_TIMEOUT` | Bootstrap workflow didn't label the issue within 20min | The `issueUrl` field in the JSON has the issue URL; check the Actions run in `octodemo/bootstrap`. When ready, re-run: `bash scripts/use-demo.sh --issue <n>` |
 | `ERR_BAD_ISSUE_TITLE` | Issue title doesn't match expected format | Verify the bootstrap issue title follows the pattern `Demo for <repo-slug>` |
+| `ERR_INVALID_ARGS` | `use-demo.sh` was called with an unknown flag or missing `--issue` value | Re-run with `bash scripts/use-demo.sh [--issue <number>]` |
 
 ## Important
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Discovers your open `demo::provisioned` issue in `octodemo/bootstrap`, parses th
 repo slug from the issue title, rewrites `GITHUB_ORG` and `GITHUB_REPO` in `.env`,
 and prints the manual next step to restart the sync-server and trigger a sync:
 ```bash
-docker compose restart sync-server
+docker compose up -d sync-server
 curl -X POST http://localhost:3005/sync
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ custom-metrics-dashboard-grafana-1         Up
 
 ```bash
 # Trigger a full sync (fetches GitHub data and loads into PostgreSQL)
-curl -X POST http://localhost:3005/api/sync
+curl -X POST http://localhost:3005/sync
 
 # Watch for completion:
 # Returns: { "jobId": "..." } 
+# Note: the manual trigger endpoint is POST /sync (not /api/sync)
 # Poll: GET http://localhost:3005/api/sync/jobs/{jobId}
 # Syncs typically complete in 30–60 seconds depending on data volume
 ```
@@ -340,7 +341,7 @@ This launches:
 ### Manually Trigger a Sync
 
 ```bash
-curl -X POST http://localhost:3005/api/sync
+curl -X POST http://localhost:3005/sync
 ```
 
 Response:
@@ -373,11 +374,11 @@ Expected response when complete:
 
 ### Automated Syncs
 
-The sync server **does not include a scheduler**. For recurring syncs, use an external cron job or GitHub Actions workflow to call the `/api/sync` endpoint.
+The sync server **does not include a scheduler**. For recurring syncs, use an external cron job or GitHub Actions workflow to call the `/sync` endpoint.
 
 Example cron (run every 6 hours):
 ```bash
-0 */6 * * * curl -X POST http://localhost:3005/api/sync
+0 */6 * * * curl -X POST http://localhost:3005/sync
 ```
 
 ---
@@ -443,7 +444,7 @@ npm run test:e2e
    ```bash
    docker exec custom-metrics-dashboard-postgres-1 psql -U postgres -d metrics -c "SELECT COUNT(*) FROM sync_jobs;"
    ```
-   If returns `0`, trigger a sync: `curl -X POST http://localhost:3005/api/sync`
+   If returns `0`, trigger a sync: `curl -X POST http://localhost:3005/sync`
 
 3. **Check Copilot metrics were fetched:**
    ```bash

--- a/README.md
+++ b/README.md
@@ -90,13 +90,16 @@ bash scripts/use-demo.sh
 ```
 
 Discovers your open `demo::provisioned` issue in `octodemo/bootstrap`, parses the
-repo slug from the issue title, updates `GITHUB_ORG` and `GITHUB_REPO` in `.env`,
-restarts the sync-server container, and triggers a full data sync.
+repo slug from the issue title, and updates `GITHUB_ORG` and `GITHUB_REPO` in `.env`.
+
+After running the script, restart the sync-server and trigger a sync manually:
+```bash
+docker compose restart sync-server
+curl -X POST http://localhost:3005/sync
+```
 
 Optional flags:
-- `--dry-run` — show what would change without modifying `.env` or Docker
 - `--issue <n>` — use a specific bootstrap issue number instead of auto-discovery
-- `--skip-sync` — rewrite `.env` only; skip docker compose and sync
 
 ### Create a new demo + configure
 
@@ -106,9 +109,8 @@ bash scripts/create-demo.sh
 
 Opens a new issue in `octodemo/bootstrap` using the OctoCat Supply Platform template,
 polls every 30 seconds until the `demo::provisioned` label appears (up to 20 minutes),
-then delegates to `use-demo.sh` automatically.
-
-Optional flags: `--backend nodejs|python|java|php`, `--azure no|yes`, `--version v4.10.0`, `--timeout-min 20`
+then delegates to `use-demo.sh` automatically. After the script completes, restart the
+sync-server and trigger a sync manually (see above).
 
 ### What changes (and what doesn't)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,63 @@ Navigate to **http://localhost:3006** (user: `admin` / password: `admin`)
 
 ---
 
+## Ephemeral Demo Environments (`octodemo/bootstrap`)
+
+If you are using an [octodemo/bootstrap](https://github.com/octodemo/bootstrap)-provisioned
+demo environment, the dashboard's `GITHUB_ORG` and `GITHUB_REPO` values must be updated
+each time a new demo is created (bootstrap demos are torn down weekly).
+
+Two scripts automate this. Both require `bash` (Git for Windows or WSL on Windows)
+and the [`gh` CLI](https://cli.github.com/) authenticated against `github.com`.
+
+### Point the dashboard at your current provisioned demo
+
+```bash
+bash scripts/use-demo.sh
+```
+
+Discovers your open `demo::provisioned` issue in `octodemo/bootstrap`, parses the
+repo slug from the issue title, updates `GITHUB_ORG` and `GITHUB_REPO` in `.env`,
+restarts the sync-server container, and triggers a full data sync.
+
+Optional flags:
+- `--dry-run` — show what would change without modifying `.env` or Docker
+- `--issue <n>` — use a specific bootstrap issue number instead of auto-discovery
+- `--skip-sync` — rewrite `.env` only; skip docker compose and sync
+
+### Create a new demo + configure
+
+```bash
+bash scripts/create-demo.sh
+```
+
+Opens a new issue in `octodemo/bootstrap` using the OctoCat Supply Platform template,
+polls every 30 seconds until the `demo::provisioned` label appears (up to 20 minutes),
+then delegates to `use-demo.sh` automatically.
+
+Optional flags: `--backend nodejs|python|java|php`, `--azure no|yes`, `--version v4.10.0`, `--timeout-min 20`
+
+### What changes (and what doesn't)
+
+| Value | Updated by scripts | Notes |
+|---|---|---|
+| `GITHUB_ORG` | ✅ Always set to `octodemo` | Constant across all bootstrap demos |
+| `GITHUB_REPO` | ✅ Parsed from bootstrap issue title | Changes each new demo |
+| `GITHUB_ENTERPRISE` | ❌ Never touched | Set manually once; constant across demos |
+| `GITHUB_TOKEN` | ❌ Never touched | Manage via `setup-env` skill |
+
+### Agent automation (Copilot skill)
+
+The **`refresh-demo-env`** skill (`.github/skills/refresh-demo-env/SKILL.md`) provides
+an agent-driven decision tree: it checks whether a sufficiently-recent provisioned demo
+already exists and calls `use-demo.sh` or `create-demo.sh` accordingly. Use it when you
+want Copilot to handle the refresh autonomously.
+
+> **Note:** `octodemo/bootstrap` is a private repository. Both scripts require that your
+> `gh` CLI account and your `GITHUB_TOKEN` (in `.env`) are members of the `octodemo` org.
+
+---
+
 ## Dashboards Overview
 
 Six dashboards are available, numbered sequentially for reference. Each reflects a different perspective on Copilot adoption and engineering success:

--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ bash scripts/use-demo.sh
 ```
 
 Discovers your open `demo::provisioned` issue in `octodemo/bootstrap`, parses the
-repo slug from the issue title, and updates `GITHUB_ORG` and `GITHUB_REPO` in `.env`.
-
-After running the script, restart the sync-server and trigger a sync manually:
+repo slug from the issue title, rewrites `GITHUB_ORG` and `GITHUB_REPO` in `.env`,
+and prints the manual next step to restart the sync-server and trigger a sync:
 ```bash
 docker compose restart sync-server
 curl -X POST http://localhost:3005/sync
@@ -109,8 +108,8 @@ bash scripts/create-demo.sh
 
 Opens a new issue in `octodemo/bootstrap` using the OctoCat Supply Platform template,
 polls every 30 seconds until the `demo::provisioned` label appears (up to 20 minutes),
-then delegates to `use-demo.sh` automatically. After the script completes, restart the
-sync-server and trigger a sync manually (see above).
+then delegates to `use-demo.sh` automatically, which prints the manual restart/sync
+step shown above.
 
 ### What changes (and what doesn't)
 

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -64,17 +64,16 @@ No
 
 v4.10.0'
 
-ISSUE_JSON="$(printf '%s' "$ISSUE_BODY" | \
+ISSUE_URL="$(printf '%s' "$ISSUE_BODY" | \
   gh issue create \
     -R "$BOOTSTRAP_REPO" \
     -t "Demo Creation :: OctoCat Supply Platform :: v4.10.0" \
     -l "demo" \
     -l "template" \
-    -F - \
-    --json number,url)"
+    -F -)"
 
+ISSUE_JSON="$(gh issue view "$ISSUE_URL" -R "$BOOTSTRAP_REPO" --json number,url)"
 ISSUE_NUMBER="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
-ISSUE_URL="$(printf '%s' "$ISSUE_JSON" | grep -o '"url":"[^"]*"' | sed 's/"url":"//;s/"$//')"
 log "Created issue #$ISSUE_NUMBER: $ISSUE_URL"
 
 # --- Poll for demo::provisioned label ----------------------------------------

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -28,8 +28,6 @@ BACKEND="nodejs"
 AZURE="No"
 VERSION="v4.10.0"
 TIMEOUT_MIN=20
-DRY_RUN=false
-SKIP_SYNC=false
 BOOTSTRAP_REPO="octodemo/bootstrap"
 DEDUPE_MARKER="created-by: refresh-demo-env"
 
@@ -39,12 +37,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --backend)     BACKEND="$2";                        shift 2 ;;
-    --azure)       AZURE="$2";                          shift 2 ;;
-    --version)     VERSION="$2";                        shift 2 ;;
-    --timeout-min) TIMEOUT_MIN="$2";                    shift 2 ;;
-    --dry-run)     DRY_RUN=true;                        shift ;;
-    --skip-sync)   SKIP_SYNC=true;                      shift ;;
+    --backend)     BACKEND="$2";     shift 2 ;;
+    --azure)       AZURE="$2";       shift 2 ;;
+    --version)     VERSION="$2";     shift 2 ;;
+    --timeout-min) TIMEOUT_MIN="$2"; shift 2 ;;
     *) echo "Unknown flag: $1" >&2; exit 1 ;;
   esac
 done
@@ -208,10 +204,4 @@ done
 
 log "Provisioning complete. Delegating to use-demo.sh --issue $ISSUE_NUMBER..."
 
-EXTRA_FLAGS=()
-$DRY_RUN   && EXTRA_FLAGS+=("--dry-run")
-$SKIP_SYNC && EXTRA_FLAGS+=("--skip-sync")
-
-exec bash "$SCRIPT_DIR/use-demo.sh" \
-  --issue "$ISSUE_NUMBER" \
-  "${EXTRA_FLAGS[@]}"
+exec bash "$SCRIPT_DIR/use-demo.sh" --issue "$ISSUE_NUMBER"

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -1,72 +1,37 @@
 #!/usr/bin/env bash
-# create-demo.sh — Create a new octodemo/bootstrap demo environment and
-# configure the CustomMetricsDashboard to point at it.
+# create-demo.sh — Create a new OctoCat Supply Platform demo in octodemo/bootstrap
+# and configure the dashboard to point at it.
 #
-# Usage:
-#   bash scripts/create-demo.sh [--backend nodejs|python|java|php]
-#                               [--azure no|yes]
-#                               [--version v4.10.0]
-#                               [--timeout-min 20]
-#                               [--dry-run]
-#                               [--skip-sync]
+# Usage: bash scripts/create-demo.sh
 #
-# After the issue is labeled demo::provisioned this script exec-replaces
-# itself with use-demo.sh so the final JSON output follows the same contract.
+# Polls every 30s (up to 20min) for the demo::provisioned label, then
+# delegates to use-demo.sh to update .env.
 #
 # Error codes:
-#   ERR_GH_AUTH             gh CLI is not authenticated or bootstrap unreachable
-#   ERR_PROVISION_TIMEOUT   issue was not labeled demo::provisioned within timeout
+#   ERR_GH_AUTH            gh CLI not authenticated or bootstrap unreachable
+#   ERR_PROVISION_TIMEOUT  issue not labeled demo::provisioned within 20 minutes
 
 set -euo pipefail
 
 # Prevent Git Bash on Windows from rewriting /repos/... paths as filesystem paths.
 export MSYS_NO_PATHCONV=1
 
-# ─── Defaults ────────────────────────────────────────────────────────────────
-
-BACKEND="nodejs"
-AZURE="No"
-VERSION="v4.10.0"
-TIMEOUT_MIN=20
 BOOTSTRAP_REPO="octodemo/bootstrap"
-DEDUPE_MARKER="created-by: refresh-demo-env"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TIMEOUT_MIN=20
+ISSUE_URL=""
 
-# ─── Arg parsing ─────────────────────────────────────────────────────────────
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --backend)     BACKEND="$2";     shift 2 ;;
-    --azure)       AZURE="$2";       shift 2 ;;
-    --version)     VERSION="$2";     shift 2 ;;
-    --timeout-min) TIMEOUT_MIN="$2"; shift 2 ;;
-    *) echo "Unknown flag: $1" >&2; exit 1 ;;
-  esac
-done
-
-# Normalize azure flag
-case "${AZURE,,}" in
-  yes|y|true)  AZURE="Yes" ;;
-  no|n|false)  AZURE="No"  ;;
-esac
-
-# ─── Helpers ─────────────────────────────────────────────────────────────────
+log() { echo "[create-demo] $*" >&2; }
 
 emit_error() {
   local code="$1" msg="$2" hint="${3:-}"
   printf '{"status":"error","code":"%s","message":"%s","hint":"%s","issueUrl":"%s"}\n' \
-    "$code" "$msg" "$hint" "${ISSUE_URL:-}"
+    "$code" "$msg" "$hint" "$ISSUE_URL"
   exit 1
 }
 
-log() { echo "[create-demo] $*" >&2; }
+# --- Pre-flight: gh CLI auth --------------------------------------------------
 
-ISSUE_URL=""
-
-# ─── Pre-flight A: gh CLI auth + bootstrap repo access ───────────────────────
-
-log "Pre-flight: checking gh CLI auth..."
 if ! gh auth status --hostname github.com >/dev/null 2>&1; then
   emit_error "ERR_GH_AUTH" \
     "gh CLI is not authenticated against github.com" \
@@ -75,133 +40,69 @@ fi
 
 if ! gh api "/repos/$BOOTSTRAP_REPO" --silent 2>/dev/null; then
   emit_error "ERR_GH_AUTH" \
-    "Cannot reach octodemo/bootstrap (401/403/404 from gh CLI)" \
+    "Cannot reach octodemo/bootstrap (401/403/404)" \
     "Ensure your gh account is a member of octodemo with repo access"
 fi
 
-GH_USER="$(gh api /user --jq '.login' 2>/dev/null)"
-log "gh user: $GH_USER"
+# --- Create issue -------------------------------------------------------------
 
-# ─── Dedupe: reuse a recent unprovisioned issue if <24h old ──────────────────
+log "Creating demo issue in $BOOTSTRAP_REPO..."
 
-log "Checking for recent unprovisioned issue with dedupe marker..."
-EXISTING_ISSUE=""
-EXISTING_ISSUES="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
-  -f "state=open" \
-  -f "creator=$GH_USER" \
-  -f "per_page=10" \
-  --jq '[.[] | select(.labels | map(.name) | contains(["demo::provisioned"]) | not) | {number, title, html_url, created_at, body}]' \
-  2>/dev/null || echo '[]')"
+ISSUE_BODY='### Backend
 
-CUTOFF_TS="$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
-             date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
-             echo "")"
-
-while IFS= read -r num; do
-  [[ -z "$num" ]] && continue
-  issue_body="$(gh issue view "$num" -R "$BOOTSTRAP_REPO" --json body --jq '.body' 2>/dev/null || echo "")"
-  issue_created="$(gh issue view "$num" -R "$BOOTSTRAP_REPO" --json createdAt --jq '.createdAt' 2>/dev/null || echo "")"
-
-  if printf '%s' "$issue_body" | grep -qF "$DEDUPE_MARKER"; then
-    # Check if <24h old (best-effort; skip if date comparison unavailable)
-    if [[ -n "$CUTOFF_TS" && "$issue_created" < "$CUTOFF_TS" ]]; then
-      log "  Found dedupe issue #$num but it is >24h old — will create a new one"
-    else
-      log "  Reusing existing unprovisioned issue #$num (< 24h old)"
-      EXISTING_ISSUE="$num"
-      break
-    fi
-  fi
-done < <(printf '%s' "$EXISTING_ISSUES" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')
-
-# ─── Create or reuse issue ────────────────────────────────────────────────────
-
-if [[ -n "$EXISTING_ISSUE" ]]; then
-  ISSUE_NUMBER="$EXISTING_ISSUE"
-  ISSUE_URL="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" --json url --jq '.url')"
-  log "Reusing issue #$ISSUE_NUMBER: $ISSUE_URL"
-else
-  ISSUE_TITLE="Demo Creation :: OctoCat Supply Platform :: $VERSION"
-
-  # Build Issue Forms canonical markdown body
-  ISSUE_BODY="### Backend
-
-$BACKEND
+nodejs
 
 ### Needs Azure Deployment?
 
-$AZURE
+No
 
 ### Bootstrap Demo Definition
 
-\`{\"url\":\"https://github.com/octodemo-framework/demo_octocat_supply\"}\`
+`{"url":"https://github.com/octodemo-framework/demo_octocat_supply"}`
 
 ### Demo Version
 
-$VERSION
+v4.10.0'
 
-<!-- $DEDUPE_MARKER -->"
+ISSUE_JSON="$(printf '%s' "$ISSUE_BODY" | \
+  gh issue create \
+    -R "$BOOTSTRAP_REPO" \
+    -t "Demo Creation :: OctoCat Supply Platform :: v4.10.0" \
+    -l "demo" \
+    -l "template" \
+    -F - \
+    --json number,url)"
 
-  if $DRY_RUN; then
-    log "DRY RUN — would create issue in $BOOTSTRAP_REPO:"
-    log "  Title: $ISSUE_TITLE"
-    log "  Backend: $BACKEND | Azure: $AZURE | Version: $VERSION"
-    printf '{"status":"success","action":"dry-run-create","newOrg":"octodemo","newRepo":"<pending>","issueUrl":"<not-created>","grafanaUrl":"http://localhost:3006/d/overview"}\n'
-    exit 0
-  fi
+ISSUE_NUMBER="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
+ISSUE_URL="$(printf '%s' "$ISSUE_JSON" | grep -o '"url":"[^"]*"' | sed 's/"url":"//;s/"$//')"
+log "Created issue #$ISSUE_NUMBER: $ISSUE_URL"
 
-  log "Creating issue in $BOOTSTRAP_REPO..."
-  ISSUE_JSON="$(printf '%s' "$ISSUE_BODY" | \
-    gh issue create \
-      -R "$BOOTSTRAP_REPO" \
-      -t "$ISSUE_TITLE" \
-      -l "demo" \
-      -l "template" \
-      -F - \
-      --json number,url 2>/dev/null)"
+# --- Poll for demo::provisioned label ----------------------------------------
 
-  ISSUE_NUMBER="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
-  ISSUE_URL="$(printf '%s' "$ISSUE_JSON" | grep -o '"url":"[^"]*"' | sed 's/"url":"//;s/"$//')"
-  log "Created issue #$ISSUE_NUMBER: $ISSUE_URL"
-fi
-
-# ─── Poll for demo::provisioned label ────────────────────────────────────────
-
-log "Polling for demo::provisioned label (timeout: ${TIMEOUT_MIN}min)..."
+log "Waiting for provisioning (up to ${TIMEOUT_MIN}min, polling every 30s)..."
 DEADLINE=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
-POLL_INTERVAL=30
-DOTS=0
 
 while true; do
-  NOW="$(date +%s)"
-  if [[ "$NOW" -ge "$DEADLINE" ]]; then
+  if [[ "$(date +%s)" -ge "$DEADLINE" ]]; then
     emit_error "ERR_PROVISION_TIMEOUT" \
-      "Issue #$ISSUE_NUMBER was not labeled demo::provisioned within ${TIMEOUT_MIN} minutes" \
-      "The bootstrap workflow may still be running. Re-run: bash scripts/use-demo.sh --issue $ISSUE_NUMBER"
+      "Issue #$ISSUE_NUMBER not labeled demo::provisioned within ${TIMEOUT_MIN} minutes" \
+      "Re-run once ready: bash scripts/use-demo.sh --issue $ISSUE_NUMBER"
   fi
 
-  ISSUE_DATA="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" \
-    --json labels,title 2>/dev/null || echo '{}')"
-
-  LABELS="$(printf '%s' "$ISSUE_DATA" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//' | tr '\n' ',' || echo "")"
-  TITLE="$(printf '%s' "$ISSUE_DATA" | grep -o '"title":"[^"]*"' | head -1 | sed 's/"title":"//;s/"$//' || echo "")"
+  ISSUE_DATA="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" --json labels,title)"
+  LABELS="$(printf '%s' "$ISSUE_DATA" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//' | tr '\n' ',')"
+  TITLE="$(printf '%s' "$ISSUE_DATA" | grep -o '"title":"[^"]*"' | head -1 | sed 's/"title":"//;s/"$//')"
 
   if printf '%s' "$LABELS" | grep -q "demo::provisioned" && \
-     printf '%s' "$TITLE" | grep -q "^Demo ::"; then
-    log ""
-    log "  Provisioned! Title: $TITLE"
+     printf '%s' "$TITLE"  | grep -q "^Demo ::"; then
+    log "Provisioned! $TITLE"
     break
   fi
 
-  DOTS=$(( (DOTS + 1) % 4 ))
-  SPINNER="$(printf '%0.s.' $(seq 1 $((DOTS + 1))))"
-  printf '\r[create-demo] Waiting for provisioning%s (%.0fs elapsed)   ' \
-    "$SPINNER" "$(( NOW - (DEADLINE - TIMEOUT_MIN * 60) ))" >&2
-  sleep "$POLL_INTERVAL"
+  log "Not yet provisioned — sleeping 30s..."
+  sleep 30
 done
 
-# ─── Delegate to use-demo.sh ─────────────────────────────────────────────────
-
-log "Provisioning complete. Delegating to use-demo.sh --issue $ISSUE_NUMBER..."
+# --- Delegate to use-demo.sh --------------------------------------------------
 
 exec bash "$SCRIPT_DIR/use-demo.sh" --issue "$ISSUE_NUMBER"

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -81,9 +81,19 @@ ISSUE_URL="$(printf '%s' "$ISSUE_BODY" | \
     -t "Demo Creation :: OctoCat Supply Platform :: v4.10.0" \
     -l "demo" \
     -l "template" \
-    -F -)"
+    -F - 2>/dev/null)" || true
+if [[ -z "$ISSUE_URL" ]]; then
+  emit_error "ERR_GH_AUTH" \
+    "Failed to create demo issue in $BOOTSTRAP_REPO" \
+    "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
+fi
 
-ISSUE_JSON="$(gh issue view "$ISSUE_URL" -R "$BOOTSTRAP_REPO" --json number,url)"
+ISSUE_JSON="$(gh issue view "$ISSUE_URL" -R "$BOOTSTRAP_REPO" --json number,url 2>/dev/null)" || true
+if [[ -z "$ISSUE_JSON" ]]; then
+  emit_error "ERR_GH_AUTH" \
+    "Failed to read newly created demo issue from $BOOTSTRAP_REPO" \
+    "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
+fi
 ISSUE_NUMBER="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
 log "Created issue #$ISSUE_NUMBER: $ISSUE_URL"
 
@@ -99,7 +109,12 @@ while true; do
       "Re-run once ready: bash scripts/use-demo.sh --issue $ISSUE_NUMBER"
   fi
 
-  ISSUE_DATA="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" --json labels,title)"
+  ISSUE_DATA="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" --json labels,title 2>/dev/null)" || true
+  if [[ -z "$ISSUE_DATA" ]]; then
+    emit_error "ERR_GH_AUTH" \
+      "Failed to read issue #$ISSUE_NUMBER from $BOOTSTRAP_REPO" \
+      "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
+  fi
   LABELS="$(printf '%s' "$ISSUE_DATA" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//' | tr '\n' ',')"
   TITLE="$(printf '%s' "$ISSUE_DATA" | grep -o '"title":"[^"]*"' | head -1 | sed 's/"title":"//;s/"$//')"
 

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -23,10 +23,21 @@ ISSUE_URL=""
 
 log() { echo "[create-demo] $*" >&2; }
 
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  printf '%s' "$s"
+}
+
 emit_error() {
   local code="$1" msg="$2" hint="${3:-}"
   printf '{"status":"error","code":"%s","message":"%s","hint":"%s","issueUrl":"%s"}\n' \
-    "$code" "$msg" "$hint" "$ISSUE_URL"
+    "$(json_escape "$code")" \
+    "$(json_escape "$msg")" \
+    "$(json_escape "$hint")" \
+    "$(json_escape "$ISSUE_URL")"
   exit 1
 }
 

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -88,13 +88,12 @@ if [[ -z "$ISSUE_URL" ]]; then
     "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
 fi
 
-ISSUE_JSON="$(gh issue view "$ISSUE_URL" -R "$BOOTSTRAP_REPO" --json number,url 2>/dev/null)" || true
-if [[ -z "$ISSUE_JSON" ]]; then
+ISSUE_NUMBER="$(gh issue view "$ISSUE_URL" -R "$BOOTSTRAP_REPO" --jq '.number' 2>/dev/null)" || true
+if [[ -z "$ISSUE_NUMBER" ]]; then
   emit_error "ERR_GH_AUTH" \
-    "Failed to read newly created demo issue from $BOOTSTRAP_REPO" \
+    "Failed to read issue number from $ISSUE_URL" \
     "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
 fi
-ISSUE_NUMBER="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
 log "Created issue #$ISSUE_NUMBER: $ISSUE_URL"
 
 # --- Poll for demo::provisioned label ----------------------------------------
@@ -109,14 +108,15 @@ while true; do
       "Re-run once ready: bash scripts/use-demo.sh --issue $ISSUE_NUMBER"
   fi
 
-  ISSUE_DATA="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" --json labels,title 2>/dev/null)" || true
-  if [[ -z "$ISSUE_DATA" ]]; then
-    emit_error "ERR_GH_AUTH" \
-      "Failed to read issue #$ISSUE_NUMBER from $BOOTSTRAP_REPO" \
-      "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
+  POLL_RESULT="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" \
+    --jq '(.labels | map(.name) | join(",")) + "|" + .title' 2>/dev/null)" || true
+  if [[ -z "$POLL_RESULT" ]]; then
+    log "Warning: failed to read issue status -- will retry"
+    sleep 30
+    continue
   fi
-  LABELS="$(printf '%s' "$ISSUE_DATA" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//' | tr '\n' ',')"
-  TITLE="$(printf '%s' "$ISSUE_DATA" | grep -o '"title":"[^"]*"' | head -1 | sed 's/"title":"//;s/"$//')"
+  LABELS="${POLL_RESULT%%|*}"
+  TITLE="${POLL_RESULT#*|}"
 
   if printf '%s' "$LABELS" | grep -q "demo::provisioned" && \
      printf '%s' "$TITLE"  | grep -q "^Demo ::"; then

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# create-demo.sh — Create a new octodemo/bootstrap demo environment and
+# configure the CustomMetricsDashboard to point at it.
+#
+# Usage:
+#   bash scripts/create-demo.sh [--backend nodejs|python|java|php]
+#                               [--azure no|yes]
+#                               [--version v4.10.0]
+#                               [--timeout-min 20]
+#                               [--dry-run]
+#                               [--skip-sync]
+#
+# After the issue is labeled demo::provisioned this script exec-replaces
+# itself with use-demo.sh so the final JSON output follows the same contract.
+#
+# Error codes:
+#   ERR_GH_AUTH             gh CLI is not authenticated or bootstrap unreachable
+#   ERR_PROVISION_TIMEOUT   issue was not labeled demo::provisioned within timeout
+
+set -euo pipefail
+
+# Prevent Git Bash on Windows from rewriting /repos/... paths as filesystem paths.
+export MSYS_NO_PATHCONV=1
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+
+BACKEND="nodejs"
+AZURE="No"
+VERSION="v4.10.0"
+TIMEOUT_MIN=20
+DRY_RUN=false
+SKIP_SYNC=false
+BOOTSTRAP_REPO="octodemo/bootstrap"
+DEDUPE_MARKER="created-by: refresh-demo-env"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ─── Arg parsing ─────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --backend)     BACKEND="$2";                        shift 2 ;;
+    --azure)       AZURE="$2";                          shift 2 ;;
+    --version)     VERSION="$2";                        shift 2 ;;
+    --timeout-min) TIMEOUT_MIN="$2";                    shift 2 ;;
+    --dry-run)     DRY_RUN=true;                        shift ;;
+    --skip-sync)   SKIP_SYNC=true;                      shift ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Normalize azure flag
+case "${AZURE,,}" in
+  yes|y|true)  AZURE="Yes" ;;
+  no|n|false)  AZURE="No"  ;;
+esac
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+emit_error() {
+  local code="$1" msg="$2" hint="${3:-}"
+  printf '{"status":"error","code":"%s","message":"%s","hint":"%s","issueUrl":"%s"}\n' \
+    "$code" "$msg" "$hint" "${ISSUE_URL:-}"
+  exit 1
+}
+
+log() { echo "[create-demo] $*" >&2; }
+
+ISSUE_URL=""
+
+# ─── Pre-flight A: gh CLI auth + bootstrap repo access ───────────────────────
+
+log "Pre-flight: checking gh CLI auth..."
+if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  emit_error "ERR_GH_AUTH" \
+    "gh CLI is not authenticated against github.com" \
+    "Run: gh auth login --hostname github.com"
+fi
+
+if ! gh api "/repos/$BOOTSTRAP_REPO" --silent 2>/dev/null; then
+  emit_error "ERR_GH_AUTH" \
+    "Cannot reach octodemo/bootstrap (401/403/404 from gh CLI)" \
+    "Ensure your gh account is a member of octodemo with repo access"
+fi
+
+GH_USER="$(gh api /user --jq '.login' 2>/dev/null)"
+log "gh user: $GH_USER"
+
+# ─── Dedupe: reuse a recent unprovisioned issue if <24h old ──────────────────
+
+log "Checking for recent unprovisioned issue with dedupe marker..."
+EXISTING_ISSUE=""
+EXISTING_ISSUES="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
+  -f "state=open" \
+  -f "creator=$GH_USER" \
+  -f "per_page=10" \
+  --jq '[.[] | select(.labels | map(.name) | contains(["demo::provisioned"]) | not) | {number, title, html_url, created_at, body}]' \
+  2>/dev/null || echo '[]')"
+
+CUTOFF_TS="$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+             date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+             echo "")"
+
+while IFS= read -r num; do
+  [[ -z "$num" ]] && continue
+  issue_body="$(gh issue view "$num" -R "$BOOTSTRAP_REPO" --json body --jq '.body' 2>/dev/null || echo "")"
+  issue_created="$(gh issue view "$num" -R "$BOOTSTRAP_REPO" --json createdAt --jq '.createdAt' 2>/dev/null || echo "")"
+
+  if printf '%s' "$issue_body" | grep -qF "$DEDUPE_MARKER"; then
+    # Check if <24h old (best-effort; skip if date comparison unavailable)
+    if [[ -n "$CUTOFF_TS" && "$issue_created" < "$CUTOFF_TS" ]]; then
+      log "  Found dedupe issue #$num but it is >24h old — will create a new one"
+    else
+      log "  Reusing existing unprovisioned issue #$num (< 24h old)"
+      EXISTING_ISSUE="$num"
+      break
+    fi
+  fi
+done < <(printf '%s' "$EXISTING_ISSUES" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')
+
+# ─── Create or reuse issue ────────────────────────────────────────────────────
+
+if [[ -n "$EXISTING_ISSUE" ]]; then
+  ISSUE_NUMBER="$EXISTING_ISSUE"
+  ISSUE_URL="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" --json url --jq '.url')"
+  log "Reusing issue #$ISSUE_NUMBER: $ISSUE_URL"
+else
+  ISSUE_TITLE="Demo Creation :: OctoCat Supply Platform :: $VERSION"
+
+  # Build Issue Forms canonical markdown body
+  ISSUE_BODY="### Backend
+
+$BACKEND
+
+### Needs Azure Deployment?
+
+$AZURE
+
+### Bootstrap Demo Definition
+
+\`{\"url\":\"https://github.com/octodemo-framework/demo_octocat_supply\"}\`
+
+### Demo Version
+
+$VERSION
+
+<!-- $DEDUPE_MARKER -->"
+
+  if $DRY_RUN; then
+    log "DRY RUN — would create issue in $BOOTSTRAP_REPO:"
+    log "  Title: $ISSUE_TITLE"
+    log "  Backend: $BACKEND | Azure: $AZURE | Version: $VERSION"
+    printf '{"status":"success","action":"dry-run-create","newOrg":"octodemo","newRepo":"<pending>","issueUrl":"<not-created>","grafanaUrl":"http://localhost:3006/d/overview"}\n'
+    exit 0
+  fi
+
+  log "Creating issue in $BOOTSTRAP_REPO..."
+  ISSUE_JSON="$(printf '%s' "$ISSUE_BODY" | \
+    gh issue create \
+      -R "$BOOTSTRAP_REPO" \
+      -t "$ISSUE_TITLE" \
+      -l "demo" \
+      -l "template" \
+      -F - \
+      --json number,url 2>/dev/null)"
+
+  ISSUE_NUMBER="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
+  ISSUE_URL="$(printf '%s' "$ISSUE_JSON" | grep -o '"url":"[^"]*"' | sed 's/"url":"//;s/"$//')"
+  log "Created issue #$ISSUE_NUMBER: $ISSUE_URL"
+fi
+
+# ─── Poll for demo::provisioned label ────────────────────────────────────────
+
+log "Polling for demo::provisioned label (timeout: ${TIMEOUT_MIN}min)..."
+DEADLINE=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
+POLL_INTERVAL=30
+DOTS=0
+
+while true; do
+  NOW="$(date +%s)"
+  if [[ "$NOW" -ge "$DEADLINE" ]]; then
+    emit_error "ERR_PROVISION_TIMEOUT" \
+      "Issue #$ISSUE_NUMBER was not labeled demo::provisioned within ${TIMEOUT_MIN} minutes" \
+      "The bootstrap workflow may still be running. Re-run: bash scripts/use-demo.sh --issue $ISSUE_NUMBER"
+  fi
+
+  ISSUE_DATA="$(gh issue view "$ISSUE_NUMBER" -R "$BOOTSTRAP_REPO" \
+    --json labels,title 2>/dev/null || echo '{}')"
+
+  LABELS="$(printf '%s' "$ISSUE_DATA" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//' | tr '\n' ',' || echo "")"
+  TITLE="$(printf '%s' "$ISSUE_DATA" | grep -o '"title":"[^"]*"' | head -1 | sed 's/"title":"//;s/"$//' || echo "")"
+
+  if printf '%s' "$LABELS" | grep -q "demo::provisioned" && \
+     printf '%s' "$TITLE" | grep -q "^Demo ::"; then
+    log ""
+    log "  Provisioned! Title: $TITLE"
+    break
+  fi
+
+  DOTS=$(( (DOTS + 1) % 4 ))
+  SPINNER="$(printf '%0.s.' $(seq 1 $((DOTS + 1))))"
+  printf '\r[create-demo] Waiting for provisioning%s (%.0fs elapsed)   ' \
+    "$SPINNER" "$(( NOW - (DEADLINE - TIMEOUT_MIN * 60) ))" >&2
+  sleep "$POLL_INTERVAL"
+done
+
+# ─── Delegate to use-demo.sh ─────────────────────────────────────────────────
+
+log "Provisioning complete. Delegating to use-demo.sh --issue $ISSUE_NUMBER..."
+
+EXTRA_FLAGS=()
+$DRY_RUN   && EXTRA_FLAGS+=("--dry-run")
+$SKIP_SYNC && EXTRA_FLAGS+=("--skip-sync")
+
+exec bash "$SCRIPT_DIR/use-demo.sh" \
+  --issue "$ISSUE_NUMBER" \
+  "${EXTRA_FLAGS[@]}"

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -48,17 +48,29 @@ done
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  printf '%s' "$s"
+}
+
 emit_error() {
   local code="$1" msg="$2" hint="${3:-}"
   printf '{"status":"error","code":"%s","message":"%s","hint":"%s"}\n' \
-    "$code" "$msg" "$hint"
+    "$(json_escape "$code")" \
+    "$(json_escape "$msg")" \
+    "$(json_escape "$hint")"
   exit 1
 }
 
 emit_success() {
   local new_repo="$1" issue_url="$2"
   printf '{"status":"success","action":"use","newOrg":"%s","newRepo":"%s","issueUrl":"%s"}\n' \
-    "$DEMO_ORG" "$new_repo" "$issue_url"
+    "$(json_escape "$DEMO_ORG")" \
+    "$(json_escape "$new_repo")" \
+    "$(json_escape "$issue_url")"
 }
 
 log() { echo "[use-demo] $*" >&2; }

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -9,7 +9,7 @@
 #   --issue <n>     Use a specific bootstrap issue number instead of auto-discovery.
 #
 # After running this script, restart the stack and trigger a sync manually:
-#   docker compose restart sync-server
+#   docker compose up -d sync-server
 #   curl -X POST http://localhost:3005/sync
 #
 # Error codes (emitted in JSON on non-zero exit):
@@ -245,6 +245,6 @@ grep -qE '^[[:space:]]*GITHUB_REPO=' "$TMPFILE" || echo "GITHUB_REPO=$NEW_REPO" 
 
 mv "$TMPFILE" "$ENV_FILE"
 log ".env updated: GITHUB_ORG=$DEMO_ORG, GITHUB_REPO=$NEW_REPO"
-log "Next step: docker compose restart sync-server && curl -X POST http://localhost:3005/sync"
+log "Next step: docker compose up -d sync-server && curl -X POST http://localhost:3005/sync"
 
 emit_success "$NEW_REPO" "$ISSUE_URL"

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -198,6 +198,6 @@ grep -qE '^[[:space:]]*GITHUB_REPO=' "$TMPFILE" || echo "GITHUB_REPO=$NEW_REPO" 
 
 mv "$TMPFILE" "$ENV_FILE"
 log ".env updated: GITHUB_ORG=$DEMO_ORG, GITHUB_REPO=$NEW_REPO"
-log "Next step: docker compose up -d --build && curl -X POST http://localhost:3005/sync"
+log "Next step: docker compose restart sync-server && curl -X POST http://localhost:3005/sync"
 
 emit_success "$NEW_REPO" "$ISSUE_URL"

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -37,15 +37,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENV_FILE="$REPO_ROOT/.env"
 
-# ─── Arg parsing ─────────────────────────────────────────────────────────────
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --issue) ISSUE_NUMBER="$2"; shift 2 ;;
-    *) echo "Unknown flag: $1" >&2; exit 1 ;;
-  esac
-done
-
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
 json_escape() {
@@ -74,6 +65,23 @@ emit_success() {
 }
 
 log() { echo "[use-demo] $*" >&2; }
+
+# ─── Arg parsing ─────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)
+      if [[ -z "${2:-}" ]]; then
+        emit_error "ERR_INVALID_ARGS" "--issue requires a value" "Usage: use-demo.sh --issue <number>"
+      fi
+      ISSUE_NUMBER="$2"
+      shift 2
+      ;;
+    *)
+      emit_error "ERR_INVALID_ARGS" "Unknown flag: $1" "Usage: use-demo.sh [--issue <number>]"
+      ;;
+  esac
+done
 
 # ─── Pre-flight A: gh CLI auth + bootstrap repo access ───────────────────────
 

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -112,7 +112,7 @@ fi
 
 # ─── Discover provisioned issue ──────────────────────────────────────────────
 
-GH_USER="$(gh api /user --jq '.login' 2>/dev/null)"
+GH_USER="$(gh api /user --jq '.login' 2>/dev/null)" || true
 if [[ -z "$GH_USER" ]]; then
   emit_error "ERR_GH_AUTH" \
     "Could not determine gh CLI username" \
@@ -123,7 +123,12 @@ log "gh user: $GH_USER"
 if [[ -n "$ISSUE_NUMBER" ]]; then
   log "Using specified issue #$ISSUE_NUMBER..."
   ISSUE_JSON="$(gh api "/repos/$BOOTSTRAP_REPO/issues/$ISSUE_NUMBER" \
-    --jq '{number, title, html_url}')"
+    --jq '{number, title, html_url}' 2>/dev/null)" || true
+  if [[ -z "$ISSUE_JSON" ]]; then
+    emit_error "ERR_GH_AUTH" \
+      "Could not read issue #$ISSUE_NUMBER from $BOOTSTRAP_REPO" \
+      "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
+  fi
 else
   log "Discovering provisioned demo for $GH_USER..."
   ISSUE_JSON="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
@@ -133,7 +138,13 @@ else
     -f "per_page=1" \
     -f "sort=updated" \
     -f "direction=desc" \
-    --jq '.[0] | {number, title, html_url}')"
+    --jq '.[0] | {number, title, html_url}' 2>/dev/null)" || true
+
+  if [[ -z "$ISSUE_JSON" ]]; then
+    emit_error "ERR_GH_AUTH" \
+      "Could not discover provisioned demo issues for $GH_USER" \
+      "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
+  fi
 
   if [[ "$ISSUE_JSON" == "null" || -z "$ISSUE_JSON" ]]; then
     emit_error "ERR_NO_PROVISIONED_DEMO" \

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -1,25 +1,24 @@
 #!/usr/bin/env bash
-# use-demo.sh — Configure the CustomMetricsDashboard against the user's
-# currently-provisioned octodemo/bootstrap demo environment.
+# use-demo.sh — Update .env to point the CustomMetricsDashboard at the
+# user's currently-provisioned octodemo/bootstrap demo environment.
 #
 # Usage:
-#   bash scripts/use-demo.sh [--dry-run] [--issue <number>] [--skip-sync]
+#   bash scripts/use-demo.sh [--issue <number>]
 #
 # Flags:
-#   --dry-run       Print what would change without modifying .env or Docker.
 #   --issue <n>     Use a specific bootstrap issue number instead of auto-discovery.
-#   --skip-sync     Rewrite .env but skip docker compose + sync trigger.
+#
+# After running this script, restart the stack and trigger a sync manually:
+#   docker compose up -d --build
+#   curl -X POST http://localhost:3005/sync
 #
 # Error codes (emitted in JSON on non-zero exit):
-#   ERR_GH_AUTH                   gh CLI is not authenticated or can't reach octodemo/bootstrap
-#   ERR_NO_TOKEN                  .env missing or GITHUB_TOKEN not set
-#   ERR_NO_PROVISIONED_DEMO       No demo::provisioned issue found for current user
-#   ERR_BAD_ISSUE_TITLE           Issue title doesn't match expected format
-#   ERR_DASHBOARD_TOKEN_INVALID   .env GITHUB_TOKEN returns 401 against GitHub API
+#   ERR_GH_AUTH                        gh CLI not authenticated or can't reach octodemo/bootstrap
+#   ERR_NO_TOKEN                        .env missing or GITHUB_TOKEN not set
+#   ERR_NO_PROVISIONED_DEMO             No demo::provisioned issue found for current user
+#   ERR_BAD_ISSUE_TITLE                 Issue title doesn't match expected format
+#   ERR_DASHBOARD_TOKEN_INVALID         .env GITHUB_TOKEN returns 401 against GitHub API
 #   ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS  .env GITHUB_TOKEN can't read the new demo repo (404/403)
-#   ERR_DOCKER_NOT_RUNNING        Docker daemon is not running
-#   ERR_SYNC_FAILED               POST /sync returned non-200 or error body
-#   ERR_SYNC_DID_NOT_PERSIST      app_config.repo doesn't match new repo after sync
 
 set -euo pipefail
 
@@ -28,9 +27,7 @@ export MSYS_NO_PATHCONV=1
 
 # ─── Defaults ────────────────────────────────────────────────────────────────
 
-DRY_RUN=false
 ISSUE_NUMBER=""
-SKIP_SYNC=false
 BOOTSTRAP_REPO="octodemo/bootstrap"
 DEMO_ORG="octodemo"
 
@@ -44,9 +41,7 @@ ENV_FILE="$REPO_ROOT/.env"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run)   DRY_RUN=true;  shift ;;
-    --skip-sync) SKIP_SYNC=true; shift ;;
-    --issue)     ISSUE_NUMBER="$2"; shift 2 ;;
+    --issue) ISSUE_NUMBER="$2"; shift 2 ;;
     *) echo "Unknown flag: $1" >&2; exit 1 ;;
   esac
 done
@@ -62,7 +57,7 @@ emit_error() {
 
 emit_success() {
   local new_repo="$1" issue_url="$2"
-  printf '{"status":"success","action":"use","newOrg":"%s","newRepo":"%s","issueUrl":"%s","grafanaUrl":"http://localhost:3006/d/overview"}\n' \
+  printf '{"status":"success","action":"use","newOrg":"%s","newRepo":"%s","issueUrl":"%s"}\n' \
     "$DEMO_ORG" "$new_repo" "$issue_url"
 }
 
@@ -70,7 +65,7 @@ log() { echo "[use-demo] $*" >&2; }
 
 # ─── Pre-flight A: gh CLI auth + bootstrap repo access ───────────────────────
 
-log "Pre-flight A: checking gh CLI auth..."
+log "Checking gh CLI auth..."
 if ! gh auth status --hostname github.com >/dev/null 2>&1; then
   emit_error "ERR_GH_AUTH" \
     "gh CLI is not authenticated against github.com" \
@@ -82,11 +77,9 @@ if ! gh api "/repos/$BOOTSTRAP_REPO" --silent 2>/dev/null; then
     "Cannot reach octodemo/bootstrap (401/403/404 from gh CLI)" \
     "Ensure your gh account is a member of octodemo with repo access"
 fi
-log "  gh auth OK"
 
 # ─── Pre-flight B: .env exists and has GITHUB_TOKEN ──────────────────────────
 
-log "Pre-flight B: checking .env..."
 if [[ ! -f "$ENV_FILE" ]]; then
   emit_error "ERR_NO_TOKEN" \
     ".env file not found at $ENV_FILE" \
@@ -104,7 +97,6 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
     "GITHUB_TOKEN is not set in $ENV_FILE" \
     "Add GITHUB_TOKEN=ghp_... to .env — see the setup-env skill"
 fi
-log "  .env OK (token present)"
 
 # ─── Discover provisioned issue ──────────────────────────────────────────────
 
@@ -119,31 +111,9 @@ log "gh user: $GH_USER"
 if [[ -n "$ISSUE_NUMBER" ]]; then
   log "Using specified issue #$ISSUE_NUMBER..."
   ISSUE_JSON="$(gh api "/repos/$BOOTSTRAP_REPO/issues/$ISSUE_NUMBER" \
-    --jq '{number, title, html_url, labels: [.labels[].name]}')"
+    --jq '{number, title, html_url}')"
 else
   log "Discovering provisioned demo for $GH_USER..."
-  ALL_ISSUES="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
-    -f "labels=demo::provisioned" \
-    -f "state=open" \
-    -f "creator=$GH_USER" \
-    --jq '[.[] | {number, title, html_url, labels: [.labels[].name], updated_at}]')"
-
-  COUNT="$(printf '%s' "$ALL_ISSUES" | grep -c '"number"' || true)"
-  if [[ "$COUNT" -eq 0 ]]; then
-    emit_error "ERR_NO_PROVISIONED_DEMO" \
-      "No open demo::provisioned issue found for $GH_USER in octodemo/bootstrap" \
-      "Run: bash scripts/create-demo.sh"
-  fi
-
-  if [[ "$COUNT" -gt 1 ]]; then
-    log "  WARNING: $COUNT provisioned demos found; using most recently updated"
-  fi
-
-  ISSUE_JSON="$(printf '%s' "$ALL_ISSUES" | \
-    gh api --input /dev/stdin --jq '.' 2>/dev/null || \
-    printf '%s' "$ALL_ISSUES" | \
-    grep -o '{[^}]*}' | head -1 || echo "{}")"
-  # Simpler: just re-query for the first one
   ISSUE_JSON="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
     -f "labels=demo::provisioned" \
     -f "state=open" \
@@ -152,12 +122,17 @@ else
     -f "sort=updated" \
     -f "direction=desc" \
     --jq '.[0] | {number, title, html_url}')"
+
+  if [[ "$ISSUE_JSON" == "null" || -z "$ISSUE_JSON" ]]; then
+    emit_error "ERR_NO_PROVISIONED_DEMO" \
+      "No open demo::provisioned issue found for $GH_USER in octodemo/bootstrap" \
+      "Run: bash scripts/create-demo.sh"
+  fi
 fi
 
 ISSUE_TITLE="$(printf '%s' "$ISSUE_JSON" | grep -o '"title":"[^"]*"' | sed 's/"title":"//;s/"$//')"
 ISSUE_URL="$(printf '%s' "$ISSUE_JSON" | grep -o '"html_url":"[^"]*"' | sed 's/"html_url":"//;s/"$//')"
 ISSUE_NUM="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
-
 log "Issue #$ISSUE_NUM: $ISSUE_TITLE"
 
 # ─── Parse repo slug from issue title ────────────────────────────────────────
@@ -173,7 +148,7 @@ if [[ -z "$NEW_REPO" ]]; then
 fi
 log "Parsed repo slug: $NEW_REPO"
 
-# ─── Verify dashboard token can reach the new repo ───────────────────────────
+# ─── Verify dashboard token can read the new repo ────────────────────────────
 
 log "Verifying dashboard token against octodemo/$NEW_REPO..."
 HTTP_CODE="$(curl -sS -o /dev/null -w "%{http_code}" \
@@ -190,122 +165,39 @@ case "$HTTP_CODE" in
         "Ensure the PAT owner has repo access to octodemo" ;;
   404) emit_error "ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS" \
         "GITHUB_TOKEN in .env cannot see octodemo/$NEW_REPO (got 404)" \
-        "Repo may be still provisioning, or token lacks octodemo repo scope" ;;
+        "Repo may still be provisioning, or token lacks octodemo repo scope" ;;
   *)   emit_error "ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS" \
         "Unexpected HTTP $HTTP_CODE from GitHub API for octodemo/$NEW_REPO" \
         "Check network connectivity and token validity" ;;
 esac
 
-# ─── Check if .env already has these values (idempotent fast-path) ────────────
+# ─── Backup and atomically rewrite .env ──────────────────────────────────────
 
 CURRENT_ORG="$(grep -E '^GITHUB_ORG=' "$ENV_FILE" | head -1 | cut -d= -f2- || echo "")"
 CURRENT_REPO="$(grep -E '^GITHUB_REPO=' "$ENV_FILE" | head -1 | cut -d= -f2- || echo "")"
 
 if [[ "$CURRENT_ORG" == "$DEMO_ORG" && "$CURRENT_REPO" == "$NEW_REPO" ]]; then
-  log "  .env already points to $DEMO_ORG/$NEW_REPO — no change needed"
-  if $DRY_RUN || $SKIP_SYNC; then
-    emit_success "$NEW_REPO" "$ISSUE_URL"
-  fi
-  # Still run sync in case data is stale
-fi
-
-# ─── Dry-run: show what would change ─────────────────────────────────────────
-
-if $DRY_RUN; then
-  log "DRY RUN — no files or containers modified"
-  log "  Would set GITHUB_ORG=$DEMO_ORG  (was: ${CURRENT_ORG:-<unset>})"
-  log "  Would set GITHUB_REPO=$NEW_REPO  (was: ${CURRENT_REPO:-<unset>})"
-  log "  Would backup: $ENV_FILE -> ${ENV_FILE}.bak.<ts>"
-  log "  Would run: docker compose up -d --build"
-  log "  Would POST: http://localhost:3005/sync"
+  log ".env already points to $DEMO_ORG/$NEW_REPO — no change needed"
   emit_success "$NEW_REPO" "$ISSUE_URL"
 fi
 
-# ─── Backup and atomically rewrite .env ──────────────────────────────────────
-
 BACKUP="$ENV_FILE.bak.$(date +%s)"
 cp "$ENV_FILE" "$BACKUP"
-log "  Backed up .env -> $BACKUP"
+log "Backed up .env -> $BACKUP"
 
 TMPFILE="$(mktemp)"
 awk -v new_org="$DEMO_ORG" -v new_repo="$NEW_REPO" '
-  /^[[:space:]]*GITHUB_ORG=/ { print "GITHUB_ORG=" new_org; next }
+  /^[[:space:]]*GITHUB_ORG=/  { print "GITHUB_ORG="  new_org;  next }
   /^[[:space:]]*GITHUB_REPO=/ { print "GITHUB_REPO=" new_repo; next }
   { print }
 ' "$ENV_FILE" > "$TMPFILE"
 
-# If GITHUB_ORG or GITHUB_REPO were not already in the file, append them
-if ! grep -qE '^[[:space:]]*GITHUB_ORG=' "$TMPFILE"; then
-  echo "GITHUB_ORG=$DEMO_ORG" >> "$TMPFILE"
-fi
-if ! grep -qE '^[[:space:]]*GITHUB_REPO=' "$TMPFILE"; then
-  echo "GITHUB_REPO=$NEW_REPO" >> "$TMPFILE"
-fi
+# Append if lines were absent
+grep -qE '^[[:space:]]*GITHUB_ORG='  "$TMPFILE" || echo "GITHUB_ORG=$DEMO_ORG"   >> "$TMPFILE"
+grep -qE '^[[:space:]]*GITHUB_REPO=' "$TMPFILE" || echo "GITHUB_REPO=$NEW_REPO"  >> "$TMPFILE"
 
 mv "$TMPFILE" "$ENV_FILE"
-log "  .env updated: GITHUB_ORG=$DEMO_ORG, GITHUB_REPO=$NEW_REPO"
-
-# ─── Skip-sync fast exit ─────────────────────────────────────────────────────
-
-if $SKIP_SYNC; then
-  log "  --skip-sync: skipping Docker + sync"
-  emit_success "$NEW_REPO" "$ISSUE_URL"
-fi
-
-# ─── Docker: verify daemon is running ────────────────────────────────────────
-
-log "Checking Docker daemon..."
-if ! docker info >/dev/null 2>&1; then
-  emit_error "ERR_DOCKER_NOT_RUNNING" \
-    "Docker daemon is not running" \
-    "Start Docker Desktop, then retry"
-fi
-
-# ─── Restart sync-server container with new .env ─────────────────────────────
-
-log "Running docker compose up -d --build (from $REPO_ROOT)..."
-(cd "$REPO_ROOT" && docker compose up -d --build >/dev/null 2>&1)
-
-log "Waiting for sync server to be ready on :3005..."
-for i in $(seq 1 30); do
-  if curl -sf http://localhost:3005/health >/dev/null 2>&1; then
-    log "  sync server ready (attempt $i)"
-    break
-  fi
-  if [[ "$i" -eq 30 ]]; then
-    emit_error "ERR_SYNC_FAILED" \
-      "Sync server did not become healthy within 60s" \
-      "Check logs: docker compose logs sync-server"
-  fi
-  sleep 2
-done
-
-# ─── Trigger sync ─────────────────────────────────────────────────────────────
-
-log "Triggering sync..."
-SYNC_RESPONSE="$(curl -sS -X POST http://localhost:3005/sync 2>/dev/null || echo '{"error":"curl failed"}')"
-log "  sync response: $SYNC_RESPONSE"
-
-if printf '%s' "$SYNC_RESPONSE" | grep -q '"error"'; then
-  emit_error "ERR_SYNC_FAILED" \
-    "POST /sync returned an error: $SYNC_RESPONSE" \
-    "Check logs: docker compose logs sync-server"
-fi
-
-# ─── Verify persisted to app_config ──────────────────────────────────────────
-
-log "Verifying app_config.repo in Postgres..."
-PERSISTED_REPO="$(docker exec custom-metrics-dashboard-postgres-1 \
-  psql -U postgres -d metrics -tAc \
-  "SELECT value FROM app_config WHERE key='repo'" 2>/dev/null | tr -d '[:space:]' || echo "")"
-
-if [[ "$PERSISTED_REPO" != "$NEW_REPO" ]]; then
-  emit_error "ERR_SYNC_DID_NOT_PERSIST" \
-    "app_config.repo is '$PERSISTED_REPO', expected '$NEW_REPO'" \
-    "Check sync logs: docker compose logs sync-server | tail -50"
-fi
-log "  Verified: app_config.repo = $PERSISTED_REPO"
-
-# ─── Done ─────────────────────────────────────────────────────────────────────
+log ".env updated: GITHUB_ORG=$DEMO_ORG, GITHUB_REPO=$NEW_REPO"
+log "Next step: docker compose up -d --build && curl -X POST http://localhost:3005/sync"
 
 emit_success "$NEW_REPO" "$ISSUE_URL"

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -9,10 +9,11 @@
 #   --issue <n>     Use a specific bootstrap issue number instead of auto-discovery.
 #
 # After running this script, restart the stack and trigger a sync manually:
-#   docker compose up -d --build
+#   docker compose restart sync-server
 #   curl -X POST http://localhost:3005/sync
 #
 # Error codes (emitted in JSON on non-zero exit):
+#   ERR_INVALID_ARGS                    Unknown flag or --issue missing a value
 #   ERR_GH_AUTH                        gh CLI not authenticated or can't reach octodemo/bootstrap
 #   ERR_NO_TOKEN                        .env missing or GITHUB_TOKEN not set
 #   ERR_NO_PROVISIONED_DEMO             No demo::provisioned issue found for current user
@@ -130,40 +131,54 @@ log "gh user: $GH_USER"
 
 if [[ -n "$ISSUE_NUMBER" ]]; then
   log "Using specified issue #$ISSUE_NUMBER..."
-  ISSUE_JSON="$(gh api "/repos/$BOOTSTRAP_REPO/issues/$ISSUE_NUMBER" \
-    --jq '{number, title, html_url}' 2>/dev/null)" || true
-  if [[ -z "$ISSUE_JSON" ]]; then
+  ISSUE_TITLE="$(gh api "/repos/$BOOTSTRAP_REPO/issues/$ISSUE_NUMBER" --jq '.title' 2>/dev/null)" || true
+  ISSUE_URL="$(gh api "/repos/$BOOTSTRAP_REPO/issues/$ISSUE_NUMBER" --jq '.html_url' 2>/dev/null)" || true
+  ISSUE_NUM="$ISSUE_NUMBER"
+  if [[ -z "$ISSUE_TITLE" || "$ISSUE_TITLE" == "null" || -z "$ISSUE_URL" || "$ISSUE_URL" == "null" ]]; then
     emit_error "ERR_GH_AUTH" \
       "Could not read issue #$ISSUE_NUMBER from $BOOTSTRAP_REPO" \
       "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
   fi
 else
   log "Discovering provisioned demo for $GH_USER..."
-  ISSUE_JSON="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
+  ISSUE_TITLE="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
     -f "labels=demo::provisioned" \
     -f "state=open" \
     -f "creator=$GH_USER" \
     -f "per_page=1" \
     -f "sort=updated" \
     -f "direction=desc" \
-    --jq '.[0] | {number, title, html_url}' 2>/dev/null)" || true
+    --jq '.[0].title' 2>/dev/null)" || true
+  ISSUE_URL="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
+    -f "labels=demo::provisioned" \
+    -f "state=open" \
+    -f "creator=$GH_USER" \
+    -f "per_page=1" \
+    -f "sort=updated" \
+    -f "direction=desc" \
+    --jq '.[0].html_url' 2>/dev/null)" || true
+  ISSUE_NUM="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
+    -f "labels=demo::provisioned" \
+    -f "state=open" \
+    -f "creator=$GH_USER" \
+    -f "per_page=1" \
+    -f "sort=updated" \
+    -f "direction=desc" \
+    --jq '.[0].number' 2>/dev/null)" || true
 
-  if [[ -z "$ISSUE_JSON" ]]; then
+  if [[ -z "$ISSUE_TITLE" && -z "$ISSUE_URL" && -z "$ISSUE_NUM" ]]; then
     emit_error "ERR_GH_AUTH" \
       "Could not discover provisioned demo issues for $GH_USER" \
       "Run: gh auth login and ensure you have access to $BOOTSTRAP_REPO"
   fi
 
-  if [[ "$ISSUE_JSON" == "null" || -z "$ISSUE_JSON" ]]; then
+  if [[ -z "$ISSUE_TITLE" || "$ISSUE_TITLE" == "null" ]]; then
     emit_error "ERR_NO_PROVISIONED_DEMO" \
       "No open demo::provisioned issue found for $GH_USER in octodemo/bootstrap" \
       "Run: bash scripts/create-demo.sh"
   fi
 fi
 
-ISSUE_TITLE="$(printf '%s' "$ISSUE_JSON" | grep -o '"title":"[^"]*"' | sed 's/"title":"//;s/"$//')"
-ISSUE_URL="$(printf '%s' "$ISSUE_JSON" | grep -o '"html_url":"[^"]*"' | sed 's/"html_url":"//;s/"$//')"
-ISSUE_NUM="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
 log "Issue #$ISSUE_NUM: $ISSUE_TITLE"
 
 # ─── Parse repo slug from issue title ────────────────────────────────────────
@@ -206,13 +221,14 @@ esac
 
 CURRENT_ORG="$(grep -E '^GITHUB_ORG=' "$ENV_FILE" | head -1 | cut -d= -f2- || echo "")"
 CURRENT_REPO="$(grep -E '^GITHUB_REPO=' "$ENV_FILE" | head -1 | cut -d= -f2- || echo "")"
+CURRENT_ORG_LC="${CURRENT_ORG,,}"
 
-if [[ "$CURRENT_ORG" == "$DEMO_ORG" && "$CURRENT_REPO" == "$NEW_REPO" ]]; then
+if [[ "$CURRENT_ORG_LC" == "$DEMO_ORG" && "$CURRENT_REPO" == "$NEW_REPO" ]]; then
   log ".env already points to $DEMO_ORG/$NEW_REPO — no change needed"
   emit_success "$NEW_REPO" "$ISSUE_URL"
 fi
 
-BACKUP="$ENV_FILE.bak.$(date +%s)"
+BACKUP="${TMPDIR:-/tmp}/env-use-demo-bak.$(date +%s)"
 cp "$ENV_FILE" "$BACKUP"
 log "Backed up .env -> $BACKUP"
 

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -182,8 +182,8 @@ log "Parsed repo slug: $NEW_REPO"
 # ─── Verify dashboard token can read the new repo ────────────────────────────
 
 log "Verifying dashboard token against octodemo/$NEW_REPO..."
-HTTP_CODE="$(curl -sS -o /dev/null -w "%{http_code}" \
-  -H "Authorization: Bearer $GITHUB_TOKEN" \
+HTTP_CODE="$(printf 'header = "Authorization: Bearer %s"\n' "$GITHUB_TOKEN" | \
+  curl -sS -o /dev/null -w "%{http_code}" --config - \
   "https://api.github.com/repos/$DEMO_ORG/$NEW_REPO" 2>/dev/null || echo "000")"
 
 case "$HTTP_CODE" in

--- a/scripts/use-demo.sh
+++ b/scripts/use-demo.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# use-demo.sh — Configure the CustomMetricsDashboard against the user's
+# currently-provisioned octodemo/bootstrap demo environment.
+#
+# Usage:
+#   bash scripts/use-demo.sh [--dry-run] [--issue <number>] [--skip-sync]
+#
+# Flags:
+#   --dry-run       Print what would change without modifying .env or Docker.
+#   --issue <n>     Use a specific bootstrap issue number instead of auto-discovery.
+#   --skip-sync     Rewrite .env but skip docker compose + sync trigger.
+#
+# Error codes (emitted in JSON on non-zero exit):
+#   ERR_GH_AUTH                   gh CLI is not authenticated or can't reach octodemo/bootstrap
+#   ERR_NO_TOKEN                  .env missing or GITHUB_TOKEN not set
+#   ERR_NO_PROVISIONED_DEMO       No demo::provisioned issue found for current user
+#   ERR_BAD_ISSUE_TITLE           Issue title doesn't match expected format
+#   ERR_DASHBOARD_TOKEN_INVALID   .env GITHUB_TOKEN returns 401 against GitHub API
+#   ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS  .env GITHUB_TOKEN can't read the new demo repo (404/403)
+#   ERR_DOCKER_NOT_RUNNING        Docker daemon is not running
+#   ERR_SYNC_FAILED               POST /sync returned non-200 or error body
+#   ERR_SYNC_DID_NOT_PERSIST      app_config.repo doesn't match new repo after sync
+
+set -euo pipefail
+
+# Prevent Git Bash on Windows from rewriting /repos/... paths as filesystem paths.
+export MSYS_NO_PATHCONV=1
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+
+DRY_RUN=false
+ISSUE_NUMBER=""
+SKIP_SYNC=false
+BOOTSTRAP_REPO="octodemo/bootstrap"
+DEMO_ORG="octodemo"
+
+# ─── Resolve repo root (script can be called from anywhere) ──────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+
+# ─── Arg parsing ─────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)   DRY_RUN=true;  shift ;;
+    --skip-sync) SKIP_SYNC=true; shift ;;
+    --issue)     ISSUE_NUMBER="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+emit_error() {
+  local code="$1" msg="$2" hint="${3:-}"
+  printf '{"status":"error","code":"%s","message":"%s","hint":"%s"}\n' \
+    "$code" "$msg" "$hint"
+  exit 1
+}
+
+emit_success() {
+  local new_repo="$1" issue_url="$2"
+  printf '{"status":"success","action":"use","newOrg":"%s","newRepo":"%s","issueUrl":"%s","grafanaUrl":"http://localhost:3006/d/overview"}\n' \
+    "$DEMO_ORG" "$new_repo" "$issue_url"
+}
+
+log() { echo "[use-demo] $*" >&2; }
+
+# ─── Pre-flight A: gh CLI auth + bootstrap repo access ───────────────────────
+
+log "Pre-flight A: checking gh CLI auth..."
+if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  emit_error "ERR_GH_AUTH" \
+    "gh CLI is not authenticated against github.com" \
+    "Run: gh auth login --hostname github.com"
+fi
+
+if ! gh api "/repos/$BOOTSTRAP_REPO" --silent 2>/dev/null; then
+  emit_error "ERR_GH_AUTH" \
+    "Cannot reach octodemo/bootstrap (401/403/404 from gh CLI)" \
+    "Ensure your gh account is a member of octodemo with repo access"
+fi
+log "  gh auth OK"
+
+# ─── Pre-flight B: .env exists and has GITHUB_TOKEN ──────────────────────────
+
+log "Pre-flight B: checking .env..."
+if [[ ! -f "$ENV_FILE" ]]; then
+  emit_error "ERR_NO_TOKEN" \
+    ".env file not found at $ENV_FILE" \
+    "Run: cp .env.example .env  then fill in your GITHUB_TOKEN"
+fi
+
+GITHUB_TOKEN=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  [[ "$line" =~ ^GITHUB_TOKEN=(.+)$ ]] && GITHUB_TOKEN="${BASH_REMATCH[1]}" && break
+done < "$ENV_FILE"
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  emit_error "ERR_NO_TOKEN" \
+    "GITHUB_TOKEN is not set in $ENV_FILE" \
+    "Add GITHUB_TOKEN=ghp_... to .env — see the setup-env skill"
+fi
+log "  .env OK (token present)"
+
+# ─── Discover provisioned issue ──────────────────────────────────────────────
+
+GH_USER="$(gh api /user --jq '.login' 2>/dev/null)"
+if [[ -z "$GH_USER" ]]; then
+  emit_error "ERR_GH_AUTH" \
+    "Could not determine gh CLI username" \
+    "Run: gh auth login"
+fi
+log "gh user: $GH_USER"
+
+if [[ -n "$ISSUE_NUMBER" ]]; then
+  log "Using specified issue #$ISSUE_NUMBER..."
+  ISSUE_JSON="$(gh api "/repos/$BOOTSTRAP_REPO/issues/$ISSUE_NUMBER" \
+    --jq '{number, title, html_url, labels: [.labels[].name]}')"
+else
+  log "Discovering provisioned demo for $GH_USER..."
+  ALL_ISSUES="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
+    -f "labels=demo::provisioned" \
+    -f "state=open" \
+    -f "creator=$GH_USER" \
+    --jq '[.[] | {number, title, html_url, labels: [.labels[].name], updated_at}]')"
+
+  COUNT="$(printf '%s' "$ALL_ISSUES" | grep -c '"number"' || true)"
+  if [[ "$COUNT" -eq 0 ]]; then
+    emit_error "ERR_NO_PROVISIONED_DEMO" \
+      "No open demo::provisioned issue found for $GH_USER in octodemo/bootstrap" \
+      "Run: bash scripts/create-demo.sh"
+  fi
+
+  if [[ "$COUNT" -gt 1 ]]; then
+    log "  WARNING: $COUNT provisioned demos found; using most recently updated"
+  fi
+
+  ISSUE_JSON="$(printf '%s' "$ALL_ISSUES" | \
+    gh api --input /dev/stdin --jq '.' 2>/dev/null || \
+    printf '%s' "$ALL_ISSUES" | \
+    grep -o '{[^}]*}' | head -1 || echo "{}")"
+  # Simpler: just re-query for the first one
+  ISSUE_JSON="$(gh api -X GET "/repos/$BOOTSTRAP_REPO/issues" \
+    -f "labels=demo::provisioned" \
+    -f "state=open" \
+    -f "creator=$GH_USER" \
+    -f "per_page=1" \
+    -f "sort=updated" \
+    -f "direction=desc" \
+    --jq '.[0] | {number, title, html_url}')"
+fi
+
+ISSUE_TITLE="$(printf '%s' "$ISSUE_JSON" | grep -o '"title":"[^"]*"' | sed 's/"title":"//;s/"$//')"
+ISSUE_URL="$(printf '%s' "$ISSUE_JSON" | grep -o '"html_url":"[^"]*"' | sed 's/"html_url":"//;s/"$//')"
+ISSUE_NUM="$(printf '%s' "$ISSUE_JSON" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')"
+
+log "Issue #$ISSUE_NUM: $ISSUE_TITLE"
+
+# ─── Parse repo slug from issue title ────────────────────────────────────────
+# Expected format: "Demo :: <repo-slug> :: <version> :: <actor>"
+
+NEW_REPO="$(printf '%s' "$ISSUE_TITLE" | \
+  sed -n 's/^Demo :: \([a-zA-Z0-9._-][a-zA-Z0-9._-]*\) ::.*/\1/p')"
+
+if [[ -z "$NEW_REPO" ]]; then
+  emit_error "ERR_BAD_ISSUE_TITLE" \
+    "Cannot parse repo slug from title: $ISSUE_TITLE" \
+    "Expected format: 'Demo :: <slug> :: <version> :: <actor>'"
+fi
+log "Parsed repo slug: $NEW_REPO"
+
+# ─── Verify dashboard token can reach the new repo ───────────────────────────
+
+log "Verifying dashboard token against octodemo/$NEW_REPO..."
+HTTP_CODE="$(curl -sS -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  "https://api.github.com/repos/$DEMO_ORG/$NEW_REPO" 2>/dev/null || echo "000")"
+
+case "$HTTP_CODE" in
+  200) log "  token OK" ;;
+  401) emit_error "ERR_DASHBOARD_TOKEN_INVALID" \
+        "GITHUB_TOKEN in .env is invalid or expired (got 401)" \
+        "Update GITHUB_TOKEN in .env — use the setup-env skill" ;;
+  403) emit_error "ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS" \
+        "GITHUB_TOKEN in .env cannot access octodemo/$NEW_REPO (got 403)" \
+        "Ensure the PAT owner has repo access to octodemo" ;;
+  404) emit_error "ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS" \
+        "GITHUB_TOKEN in .env cannot see octodemo/$NEW_REPO (got 404)" \
+        "Repo may be still provisioning, or token lacks octodemo repo scope" ;;
+  *)   emit_error "ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS" \
+        "Unexpected HTTP $HTTP_CODE from GitHub API for octodemo/$NEW_REPO" \
+        "Check network connectivity and token validity" ;;
+esac
+
+# ─── Check if .env already has these values (idempotent fast-path) ────────────
+
+CURRENT_ORG="$(grep -E '^GITHUB_ORG=' "$ENV_FILE" | head -1 | cut -d= -f2- || echo "")"
+CURRENT_REPO="$(grep -E '^GITHUB_REPO=' "$ENV_FILE" | head -1 | cut -d= -f2- || echo "")"
+
+if [[ "$CURRENT_ORG" == "$DEMO_ORG" && "$CURRENT_REPO" == "$NEW_REPO" ]]; then
+  log "  .env already points to $DEMO_ORG/$NEW_REPO — no change needed"
+  if $DRY_RUN || $SKIP_SYNC; then
+    emit_success "$NEW_REPO" "$ISSUE_URL"
+  fi
+  # Still run sync in case data is stale
+fi
+
+# ─── Dry-run: show what would change ─────────────────────────────────────────
+
+if $DRY_RUN; then
+  log "DRY RUN — no files or containers modified"
+  log "  Would set GITHUB_ORG=$DEMO_ORG  (was: ${CURRENT_ORG:-<unset>})"
+  log "  Would set GITHUB_REPO=$NEW_REPO  (was: ${CURRENT_REPO:-<unset>})"
+  log "  Would backup: $ENV_FILE -> ${ENV_FILE}.bak.<ts>"
+  log "  Would run: docker compose up -d --build"
+  log "  Would POST: http://localhost:3005/sync"
+  emit_success "$NEW_REPO" "$ISSUE_URL"
+fi
+
+# ─── Backup and atomically rewrite .env ──────────────────────────────────────
+
+BACKUP="$ENV_FILE.bak.$(date +%s)"
+cp "$ENV_FILE" "$BACKUP"
+log "  Backed up .env -> $BACKUP"
+
+TMPFILE="$(mktemp)"
+awk -v new_org="$DEMO_ORG" -v new_repo="$NEW_REPO" '
+  /^[[:space:]]*GITHUB_ORG=/ { print "GITHUB_ORG=" new_org; next }
+  /^[[:space:]]*GITHUB_REPO=/ { print "GITHUB_REPO=" new_repo; next }
+  { print }
+' "$ENV_FILE" > "$TMPFILE"
+
+# If GITHUB_ORG or GITHUB_REPO were not already in the file, append them
+if ! grep -qE '^[[:space:]]*GITHUB_ORG=' "$TMPFILE"; then
+  echo "GITHUB_ORG=$DEMO_ORG" >> "$TMPFILE"
+fi
+if ! grep -qE '^[[:space:]]*GITHUB_REPO=' "$TMPFILE"; then
+  echo "GITHUB_REPO=$NEW_REPO" >> "$TMPFILE"
+fi
+
+mv "$TMPFILE" "$ENV_FILE"
+log "  .env updated: GITHUB_ORG=$DEMO_ORG, GITHUB_REPO=$NEW_REPO"
+
+# ─── Skip-sync fast exit ─────────────────────────────────────────────────────
+
+if $SKIP_SYNC; then
+  log "  --skip-sync: skipping Docker + sync"
+  emit_success "$NEW_REPO" "$ISSUE_URL"
+fi
+
+# ─── Docker: verify daemon is running ────────────────────────────────────────
+
+log "Checking Docker daemon..."
+if ! docker info >/dev/null 2>&1; then
+  emit_error "ERR_DOCKER_NOT_RUNNING" \
+    "Docker daemon is not running" \
+    "Start Docker Desktop, then retry"
+fi
+
+# ─── Restart sync-server container with new .env ─────────────────────────────
+
+log "Running docker compose up -d --build (from $REPO_ROOT)..."
+(cd "$REPO_ROOT" && docker compose up -d --build >/dev/null 2>&1)
+
+log "Waiting for sync server to be ready on :3005..."
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:3005/health >/dev/null 2>&1; then
+    log "  sync server ready (attempt $i)"
+    break
+  fi
+  if [[ "$i" -eq 30 ]]; then
+    emit_error "ERR_SYNC_FAILED" \
+      "Sync server did not become healthy within 60s" \
+      "Check logs: docker compose logs sync-server"
+  fi
+  sleep 2
+done
+
+# ─── Trigger sync ─────────────────────────────────────────────────────────────
+
+log "Triggering sync..."
+SYNC_RESPONSE="$(curl -sS -X POST http://localhost:3005/sync 2>/dev/null || echo '{"error":"curl failed"}')"
+log "  sync response: $SYNC_RESPONSE"
+
+if printf '%s' "$SYNC_RESPONSE" | grep -q '"error"'; then
+  emit_error "ERR_SYNC_FAILED" \
+    "POST /sync returned an error: $SYNC_RESPONSE" \
+    "Check logs: docker compose logs sync-server"
+fi
+
+# ─── Verify persisted to app_config ──────────────────────────────────────────
+
+log "Verifying app_config.repo in Postgres..."
+PERSISTED_REPO="$(docker exec custom-metrics-dashboard-postgres-1 \
+  psql -U postgres -d metrics -tAc \
+  "SELECT value FROM app_config WHERE key='repo'" 2>/dev/null | tr -d '[:space:]' || echo "")"
+
+if [[ "$PERSISTED_REPO" != "$NEW_REPO" ]]; then
+  emit_error "ERR_SYNC_DID_NOT_PERSIST" \
+    "app_config.repo is '$PERSISTED_REPO', expected '$NEW_REPO'" \
+    "Check sync logs: docker compose logs sync-server | tail -50"
+fi
+log "  Verified: app_config.repo = $PERSISTED_REPO"
+
+# ─── Done ─────────────────────────────────────────────────────────────────────
+
+emit_success "$NEW_REPO" "$ISSUE_URL"


### PR DESCRIPTION
## Summary

Adds two bash scripts and a Copilot skill to automate reconfiguring the dashboard each time an `octodemo/bootstrap` demo environment is created or refreshed. The scripts handle `.env` updates; users then manually restart the sync-server and trigger a sync. No changes to TypeScript, dashboard JSON, or docker-compose.

## How it works

The dashboard reads `GITHUB_ORG` and `GITHUB_REPO` from `.env`. Pointing it at a new demo is a two-step operation:
1. Rewrite those two values in `.env` (automated by these scripts)
2. Restart the sync-server container + POST `/sync` (manual step)

The scripts automate step 1 and provide clear instructions for step 2.

## Files changed

| File | Purpose |
|---|---|
| `scripts/use-demo.sh` | Core script — queries `octodemo/bootstrap` for the current `demo::provisioned` issue, parses repo slug from title, atomically rewrites `.env`, validates token has access to new repo |
| `scripts/create-demo.sh` | Opens new bootstrap issue, polls every 30s for `demo::provisioned` label (up to 20min), exec-replaces itself with `use-demo.sh` |
| `.github/skills/refresh-demo-env/SKILL.md` | Agent playbook: decision tree (use vs create), error routing table for all typed error codes |
| `.env.example` | Comment block pointing to the scripts |
| `README.md` | "Ephemeral Demo Environments" section after Quick Start |

## Usage

```bash
# Point dashboard at your current provisioned demo
bash scripts/use-demo.sh

# Create a new demo + wait + configure
bash scripts/create-demo.sh

# Use a specific issue number instead of auto-discovery
bash scripts/use-demo.sh --issue 42
```

After running either script, restart the sync-server and trigger a sync:
```bash
docker compose up -d sync-server
curl -X POST http://localhost:3005/sync
```

## Auth design

Two independent auth surfaces, both pre-flighted before any destructive steps:

| Operation | Auth source |
|---|---|
| Bootstrap issue lookup/create | `gh` CLI keyring auth (`nicolehaugen` on github.com) |
| New repo access check | `GITHUB_TOKEN` in `.env` |

Rotating the dashboard PAT doesn't break the `gh` auth path, and vice versa.

## Error codes

All errors emit structured JSON: `{"status":"error","code":"ERR_...","message":"...","hint":"..."}` and exit non-zero. The skill routes each code to the correct remediation.

| Code | Cause |
|---|---|
| `ERR_GH_AUTH` | `gh` CLI not authenticated or can't reach bootstrap |
| `ERR_NO_TOKEN` | `.env` missing or `GITHUB_TOKEN` not set |
| `ERR_NO_PROVISIONED_DEMO` | No `demo::provisioned` issue for current user → run `create-demo.sh` |
| `ERR_BAD_ISSUE_TITLE` | Issue title doesn't match expected format |
| `ERR_DASHBOARD_TOKEN_INVALID` | `.env` token is expired (401) → `setup-env` skill |
| `ERR_DASHBOARD_TOKEN_NO_REPO_ACCESS` | Token can't read new repo (404/403) |
| `ERR_PROVISION_TIMEOUT` | Bootstrap workflow took &gt;20min |

## Validation

- `bash -n` syntax check passes on both scripts (Git Bash on Windows)
- JSON escaping implemented for all structured output fields (backslash, quotes, newlines)
- `|| true` guards on `gh api` command substitutions to preserve structured error contract under `set -e`
- TS build passes (no `.ts` files changed)
- `MSYS_NO_PATHCONV=1` set in both scripts for Git Bash / Windows path-rewriting compatibility

