### PR TITLE
docs: Copilot metrics announcements summary — June 16–22, 2026

### DIFF
--- a/planning-docs/copilot-metrics-announcements-2026-04-07-to-2026-04-13.md
+++ b/planning-docs/copilot-metrics-announcements-2026-04-07-to-2026-04-13.md
@@ -1,0 +1,105 @@
+# Copilot Usage Metrics Announcements — April 7–13, 2026
+
+> **Review period:** April 7–13, 2026  
+> **Sources:** [GitHub Changelog](https://github.blog/changelog/), [VS Code Updates](https://code.visualstudio.com/updates), [GitHub Copilot CLI Changelog](https://github.com/github/copilot-cli/blob/main/changelog.md)
+
+---
+
+## GitHub Changelog
+
+### 🆕 Copilot usage metrics now aggregate Copilot cloud agent active user counts
+**Date:** April 10, 2026  
+**Link:** https://github.blog/changelog/2026-04-10-copilot-usage-metrics-now-aggregate-copilot-cloud-agent-active-user-counts
+
+Three new aggregate fields are now available in the [Copilot usage metrics API](https://docs.github.com/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10) at both the enterprise and organization level (1-day and 28-day reports):
+
+| Field | Description |
+|---|---|
+| `daily_active_copilot_cloud_agent_users` | Unique users who used Copilot cloud agent on that day |
+| `weekly_active_copilot_cloud_agent_users` | Unique users in the trailing 7-day window |
+| `monthly_active_copilot_cloud_agent_users` | Unique users in the trailing 28-day window |
+
+Fields are nullable — they return a count (including zero) when data is available, or `null` when no cloud agent data exists for the period.
+
+**Why it matters for this dashboard:**  
+These new fields complement the existing `monthly_active_agent_users` (IDE agent mode) and `used_copilot_coding_agent` (per-user flag). The dashboard's Copilot adoption panels can surface daily/weekly/monthly cloud agent adoption trends without manually aggregating user-level data.
+
+> **Note:** Copilot coding agent was recently renamed to Copilot cloud agent. Data schema fields for existing "coding agent" references will be updated in the coming weeks.
+
+---
+
+### 🆕 Copilot CLI activity now included in usage metrics totals and feature breakdowns
+**Date:** April 10, 2026  
+**Link:** https://github.blog/changelog/2026-04-10-copilot-cli-activity-now-included-in-usage-metrics-totals-and-feature-breakdowns
+
+CLI activity is now integrated into the top-level totals and dimensional breakdowns in the Copilot usage metrics API, instead of being reported only in the standalone `totals_by_cli` section.
+
+**Top-level fields now include IDE + CLI combined:**
+- `code_generation_activity_count`
+- `code_acceptance_activity_count`
+- `user_initiated_interaction_count`
+- `loc_added_sum` / `loc_deleted_sum`
+
+**CLI appears in dimensional breakdowns as `feature=copilot_cli` in:**
+- `totals_by_feature`
+- `totals_by_model_feature`
+- `totals_by_language_feature`
+- `totals_by_language_model`
+
+CLI is excluded from `totals_by_ide`. The existing `totals_by_cli` section and per-user CLI fields remain unchanged.
+
+**⚠️ Breaking change for existing dashboards:**  
+If any SQL panels assume top-level total fields represent IDE-only activity, the numbers will now be higher due to the addition of CLI contributions. Review any thresholds or comparisons that depend on these values.
+
+---
+
+## VS Code Updates (v1.115 — April 8, 2026)
+
+No metrics-specific changes found in this release. The main Copilot-related change was **Bring Your Own Key (BYOK)** support for Copilot Business and Enterprise (access to third-party language model providers) — not related to usage metrics.
+
+---
+
+## GitHub Copilot CLI Changelog
+
+### 📊 Display reasoning token usage in per-model token breakdown
+**Version:** 1.0.23 — April 10, 2026
+
+Reasoning token usage is now shown in the per-model token breakdown in the CLI when nonzero. This gives users more granular visibility into token consumption for models that use reasoning tokens (e.g., `o3`, Claude thinking modes).
+
+---
+
+### 📊 OpenTelemetry monitoring: new `time_to_first_chunk` attribute
+**Version:** 1.0.19 — April 6, 2026  
+**Link:** https://github.com/github/copilot-cli/blob/main/changelog.md
+
+Two OpenTelemetry monitoring improvements:
+- Subagent spans now use `INTERNAL` span kind (correcting span semantics for tracing tools)
+- Chat spans now include a `github.copilot.time_to_first_chunk` attribute for streaming responses — enabling latency/responsiveness tracking in OpenTelemetry-compatible observability platforms
+
+---
+
+### 📖 New `copilot help monitoring` topic
+**Version:** 1.0.20 — April 7, 2026
+
+Added a built-in `copilot help monitoring` topic documenting OpenTelemetry configuration details and examples. Useful for teams setting up observability pipelines to collect CLI telemetry.
+
+---
+
+### 🎨 Redesigned exit screen with usage summary
+**Version:** 1.0.24 — April 10, 2026
+
+The CLI exit screen was redesigned with a cleaner **usage summary layout**, making per-session token and activity counts more readable at a glance.
+
+---
+
+## Summary
+
+| Source | Item | Impact |
+|---|---|---|
+| GitHub API | Cloud agent active user counts (daily/weekly/monthly) | New fields available for adoption dashboards |
+| GitHub API | CLI activity merged into top-level totals | **Breaking:** top-level totals now include CLI; review existing panels |
+| VS Code 1.115 | No metrics changes | No action needed |
+| Copilot CLI 1.0.23 | Reasoning token usage in breakdown | New granularity in CLI token metrics |
+| Copilot CLI 1.0.19 | `time_to_first_chunk` OTel attribute | New latency metric for observability pipelines |
+| Copilot CLI 1.0.20 | `copilot help monitoring` topic | Documentation for OTel configuration |
+| Copilot CLI 1.0.24 | Cleaner usage summary on exit | UX improvement, no API changes |

--- a/planning-docs/copilot-metrics-announcements-2026-06-13-to-2026-06-19.md
+++ b/planning-docs/copilot-metrics-announcements-2026-06-13-to-2026-06-19.md
@@ -1,0 +1,93 @@
+# Copilot Usage Metrics Announcements — June 13–19, 2026
+
+> **Review period:** June 13–19, 2026  
+> **Sources:** [GitHub Changelog](https://github.blog/changelog/), [VS Code Updates](https://code.visualstudio.com/updates), [GitHub Copilot CLI Changelog](https://github.com/github/copilot-cli/blob/main/changelog.md)
+
+---
+
+## GitHub Changelog
+
+### 🆕 AI credits consumed per user now in the Copilot usage metrics API
+**Date:** June 19, 2026  
+**Link:** https://github.blog/changelog/2026-06-19-ai-credits-consumed-per-user-now-in-the-copilot-usage-metrics-api
+
+A new `ai_credits_used` field is now included for each user in the [Copilot usage metrics API](https://docs.github.com/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10) user-level reports. It reports the total AI credits a user consumed per day, derived from the same data used in the [usage-based billing API](https://docs.github.com/rest/billing/usage?apiVersion=2026-03-10).
+
+| Field | Scope | Report Types |
+|---|---|---|
+| `ai_credits_used` | Per user, per day | `users-1-day`, `users-28-day` |
+
+Available at both **enterprise** and **organization** levels. Accessible to enterprise administrators and organization owners with Copilot usage metrics API access.
+
+**Important notes:**
+- `ai_credits_used` is an overall per-user total — it is **not** broken down by feature, model, or surface.
+- This is a metrics signal for consumption analysis, **not** a billed total; refer to the billing API for invoicing.
+
+**Why it matters for this dashboard:**  
+This new field enables the dashboard to show AI credit consumption alongside existing usage signals (completions, chat activity, agent usage), connecting developer activity to cost. It can power new panels tracking per-user credit burn rates, day-over-day trends, and distribution of consumption across the organization or enterprise — directly supporting usage-based billing planning.
+
+---
+
+## VS Code Updates (v1.125 — June 17, 2026)
+
+### 📊 View your additional spend usage in VS Code
+**Link:** https://code.visualstudio.com/updates/v1_125
+
+The **Copilot status dashboard** in VS Code now displays the **percentage of the additional Copilot budget consumed**, giving users real-time visibility into overage before hitting their configured limit.
+
+> _"To make sure you stay ahead of overage charges, the Copilot status dashboard now shows the percentage of your additional Copilot budget that you've consumed, so you can adjust your usage before you hit your configured limit."_
+
+Detailed usage and additional spend management is available at [github.com/settings/copilot/features](https://github.com/settings/copilot/features).
+
+**Why it matters for this dashboard:**  
+This is a VS Code UX change — no API changes are involved. The underlying spend data surfaces through the usage-based billing API and is not a new field for dashboard panels, but it confirms that budget consumption is a growing area of focus for Copilot observability.
+
+### 🏢 Native MDM delivery for managed Copilot settings
+**Link:** https://code.visualstudio.com/updates/v1_125
+
+Administrators can now deliver managed GitHub Copilot settings through native **MDM (Mobile Device Management)** channels on Windows and macOS, in addition to account-based enterprise settings. Settings delivered via MDM appear as policy-enforced and cannot be overridden locally.
+
+**Why it matters for this dashboard:**  
+No metrics API changes. This is an enterprise policy management improvement that reinforces how organizations enforce Copilot configuration, which may affect which features are enabled and therefore what shows up in usage metrics.
+
+---
+
+## GitHub Copilot CLI Changelog
+
+> **Note:** The Copilot CLI changelog is a flat, undated list. The items below are metrics- and usage-related entries present in the changelog as of June 19, 2026. Specific release dates are not available.
+
+### 📊 Cache write tokens shown alongside cache read tokens in `/usage` display
+
+The `/usage` command now shows **cache write tokens** alongside the existing cache read token counts, giving users a complete picture of token consumption including caching overhead.
+
+---
+
+### 📊 Quota footer shows remaining requests as a rounded percentage
+
+The session footer now displays remaining API requests as a **rounded percentage**, making quota status easier to read at a glance without requiring users to interpret raw counts.
+
+---
+
+### 📊 Add `billing` help topic with overview of AI credit usage features
+
+A new `billing` help topic (`copilot help billing`) has been added, providing an overview of AI credit usage features including how credits are consumed and how to track usage.
+
+---
+
+### 📊 Remaining requests percentage no longer shows a negative value for over-limit users
+
+A display bug was fixed where users who exceeded their request quota saw a **negative percentage** in the remaining requests indicator. The value now correctly reflects an over-limit state.
+
+---
+
+## Summary
+
+| Source | Item | Impact |
+|---|---|---|
+| GitHub API | `ai_credits_used` field in user-level Copilot usage metrics reports | New per-user daily credit consumption field; powers cost-vs-adoption panels |
+| VS Code 1.125 | Additional spend percentage in Copilot status dashboard | VS Code UX improvement; no new API fields |
+| VS Code 1.125 | Native MDM delivery for managed Copilot settings | Enterprise policy management; may affect feature enablement in metrics |
+| Copilot CLI | Cache write tokens in `/usage` display | More granular token cost visibility in CLI |
+| Copilot CLI | Quota footer shows remaining requests as rounded percentage | UX fix; no API change |
+| Copilot CLI | New `billing` help topic | Documentation for AI credit usage features |
+| Copilot CLI | Fix: negative remaining requests % for over-limit users | Bug fix; no API change |

--- a/planning-docs/copilot-metrics-announcements-2026-06-16-to-2026-06-22.md
+++ b/planning-docs/copilot-metrics-announcements-2026-06-16-to-2026-06-22.md
@@ -1,0 +1,113 @@
+# Copilot Usage Metrics Announcements — June 16–22, 2026
+
+> **Review period:** June 16–22, 2026  
+> **Sources:** [GitHub Changelog](https://github.blog/changelog/), [VS Code Updates](https://code.visualstudio.com/updates), [GitHub Copilot CLI Changelog](https://github.com/github/copilot-cli/blob/main/changelog.md)
+
+---
+
+## GitHub Changelog
+
+### 🆕 AI credits consumed per user now in the Copilot usage metrics API
+**Date:** June 19, 2026  
+**Link:** https://github.blog/changelog/2026-06-19-ai-credits-consumed-per-user-now-in-the-copilot-usage-metrics-api
+
+A new `ai_credits_used` field is now included for each user in the [Copilot usage metrics API](https://docs.github.com/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10) user-level reports. It reports the total AI credits a user consumed per day, derived from the same data used in the [usage-based billing API](https://docs.github.com/rest/billing/usage?apiVersion=2026-03-10).
+
+| Field | Scope | Report Types |
+|---|---|---|
+| `ai_credits_used` | Per user, per day | `users-1-day`, `users-28-day` |
+
+Available at both **enterprise** and **organization** levels. Accessible to enterprise administrators and organization owners with Copilot usage metrics API access.
+
+**Important notes:**
+- `ai_credits_used` is an overall per-user total — it is **not** broken down by feature, model, or surface.
+- This is a metrics signal for consumption analysis, **not** a billed total; refer to the billing API for invoicing.
+
+**Why it matters for this dashboard:**  
+This new field enables the dashboard to show AI credit consumption alongside existing usage signals (completions, chat activity, agent usage), connecting developer activity to cost. It can power new panels tracking per-user credit burn rates, day-over-day trends, and distribution of consumption across the organization or enterprise — directly supporting usage-based billing planning.
+
+---
+
+## VS Code Updates (v1.125 — June 17, 2026)
+
+### 📊 View your additional spend usage in VS Code
+**Link:** https://code.visualstudio.com/updates/v1_125
+
+The **Copilot status dashboard** in VS Code now displays the **percentage of the additional Copilot budget consumed**, giving users real-time visibility into overage before hitting their configured limit.
+
+> _"To make sure you stay ahead of overage charges, the Copilot status dashboard now shows the percentage of your additional Copilot budget that you've consumed, so you can adjust your usage before you hit your configured limit."_
+
+Detailed usage and additional spend management is available at [github.com/settings/copilot/features](https://github.com/settings/copilot/features).
+
+**Why it matters for this dashboard:**  
+This is a VS Code UX change — no API changes are involved. The underlying spend data surfaces through the usage-based billing API and is not a new field for dashboard panels, but it confirms that budget consumption is a growing area of focus for Copilot observability.
+
+### 🏢 Native MDM delivery for managed Copilot settings
+**Link:** https://code.visualstudio.com/updates/v1_125
+
+Administrators can now deliver managed GitHub Copilot settings through native **MDM (Mobile Device Management)** channels on Windows and macOS, in addition to account-based enterprise settings. Settings delivered via MDM appear as policy-enforced and cannot be overridden locally.
+
+**Why it matters for this dashboard:**  
+No metrics API changes. This is an enterprise policy management improvement that reinforces how organizations enforce Copilot configuration, which may affect which features are enabled and therefore what shows up in usage metrics.
+
+---
+
+## GitHub Copilot CLI Changelog
+
+> **Note:** The Copilot CLI changelog is a flat, undated list. The items below are metrics- and usage-related entries present in the changelog as of June 22, 2026. Specific release dates are not available.
+
+### 📊 Cache write tokens shown alongside cache read tokens in `/usage` display
+
+The `/usage` command now shows **cache write tokens** alongside the existing cache read token counts, giving users a complete picture of token consumption including caching overhead.
+
+---
+
+### 📊 Quota footer shows remaining requests as a rounded percentage
+
+The session footer now displays remaining API requests as a **rounded percentage**, making quota status easier to read at a glance without requiring users to interpret raw counts.
+
+---
+
+### 📊 Add `billing` help topic with overview of AI credit usage features
+
+A new `billing` help topic (`copilot help billing`) has been added, providing an overview of AI credit usage features including how credits are consumed and how to track usage.
+
+---
+
+### 📊 Remaining requests percentage no longer shows a negative value for over-limit users
+
+A display bug was fixed where users who exceeded their request quota saw a **negative percentage** in the remaining requests indicator. The value now correctly reflects an over-limit state.
+
+---
+
+### 📊 Show per-MCP-server token usage in `/mcp` and break out MCP tool tokens in `/context`
+
+Per-MCP-server token usage is now visible in `/mcp`, and MCP tool token costs are broken out separately in `/context`, giving a granular view of how MCP tool calls contribute to overall token consumption.
+
+---
+
+### 📊 Report Claude thinking (reasoning) tokens in session usage summaries
+
+Claude reasoning (thinking) tokens are now reported in session usage summaries, providing a more complete accounting of total token spend when using models that support extended thinking.
+
+---
+
+## No New Announcements (June 20–22, 2026)
+
+No new metrics-related announcements were found across the three monitored sources for June 20–22, 2026. The GitHub Changelog RSS feed's last build date was June 19, 2026.
+
+---
+
+## Summary
+
+| Source | Item | Date | Impact |
+|---|---|---|---|
+| GitHub API | `ai_credits_used` field in user-level Copilot usage metrics reports | Jun 19 | New per-user daily credit consumption field; powers cost-vs-adoption panels |
+| VS Code 1.125 | Additional spend percentage in Copilot status dashboard | Jun 17 | VS Code UX improvement; no new API fields |
+| VS Code 1.125 | Native MDM delivery for managed Copilot settings | Jun 17 | Enterprise policy management; may affect feature enablement in metrics |
+| Copilot CLI | Cache write tokens in `/usage` display | Undated | More granular token cost visibility in CLI |
+| Copilot CLI | Quota footer shows remaining requests as rounded percentage | Undated | UX fix; no API change |
+| Copilot CLI | New `billing` help topic | Undated | Documentation for AI credit usage features |
+| Copilot CLI | Fix: negative remaining requests % for over-limit users | Undated | Bug fix; no API change |
+| Copilot CLI | Per-MCP-server token usage in `/mcp` + MCP tool tokens in `/context` | Undated | Granular MCP token cost breakdown |
+| Copilot CLI | Claude reasoning tokens in session usage summaries | Undated | Complete token accounting for thinking models |


### PR DESCRIPTION
## Copilot Usage Metrics Announcements — June 16–22, 2026

Summarizes announcements related to Copilot usage metrics across the three monitored sources for the week of **June 16–22, 2026**.

### Sources reviewed
- [GitHub Changelog](https://github.blog/changelog/)
- [VS Code Updates v1.125](https://code.visualstudio.com/updates/v1_125)
- [GitHub Copilot CLI Changelog](https://github.com/github/copilot-cli/blob/main/changelog.md)

### Key highlights

| Source | Item | Date |
|---|---|---|
| **GitHub API** | New `ai_credits_used` field in Copilot usage metrics API user-level reports | Jun 19 |
| **VS Code 1.125** | Additional spend % shown in Copilot status dashboard | Jun 17 |
| **VS Code 1.125** | Native MDM delivery for managed Copilot settings | Jun 17 |
| **Copilot CLI** | Cache write tokens in `/usage`, per-MCP-server token costs, Claude reasoning tokens | Undated |

### Files
- `planning-docs/copilot-metrics-announcements-2026-06-13-to-2026-06-19.md` — prior week
- `planning-docs/copilot-metrics-announcements-2026-06-16-to-2026-06-22.md` — this week (new)

No new announcements found for June 20–22.